### PR TITLE
Make `Client` and `ClientMultiWorkspace` factory methods accept only keyword arguments

### DIFF
--- a/lib/seam/client.rb
+++ b/lib/seam/client.rb
@@ -19,11 +19,11 @@ module Seam
       @defaults = {"wait_for_action_attempt" => wait_for_action_attempt}
     end
 
-    def self.from_api_key(api_key, endpoint: nil, wait_for_action_attempt: false, debug: false)
+    def self.from_api_key(api_key:, endpoint: nil, wait_for_action_attempt: false, debug: false)
       new(api_key: api_key, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
     end
 
-    def self.from_personal_access_token(personal_access_token, workspace_id, endpoint: nil, wait_for_action_attempt: false, debug: false)
+    def self.from_personal_access_token(personal_access_token:, workspace_id:, endpoint: nil, wait_for_action_attempt: false, debug: false)
       new(personal_access_token: personal_access_token, workspace_id: workspace_id, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
     end
 

--- a/lib/seam/client_multi_workspace.rb
+++ b/lib/seam/client_multi_workspace.rb
@@ -27,7 +27,7 @@ module Seam
       @workspaces ||= WorkspacesProxy.new(Seam::Clients::Workspaces.new(self))
     end
 
-    def self.from_personal_access_token(personal_access_token, endpoint: nil, wait_for_action_attempt: true)
+    def self.from_personal_access_token(personal_access_token:, endpoint: nil, wait_for_action_attempt: true)
       new(
         personal_access_token: personal_access_token,
         endpoint: endpoint,

--- a/spec/seam_client/api_key_spec.rb
+++ b/spec/seam_client/api_key_spec.rb
@@ -23,19 +23,19 @@ RSpec.describe Seam::Client do
   describe "#api_key_format" do
     it "checks api key format" do
       expect do
-        Seam::Client.from_api_key("some-invalid-key-format")
+        Seam::Client.from_api_key(api_key: "some-invalid-key-format")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_api_key("ey")
+        Seam::Client.from_api_key(api_key: "ey")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
 
       expect do
-        Seam::Client.from_api_key("seam_cst_token")
+        Seam::Client.from_api_key(api_key: "seam_cst_token")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
 
       expect do
-        Seam::Client.from_api_key("seam_at")
+        Seam::Client.from_api_key(api_key: "seam_at")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Access Token/)
     end
   end

--- a/spec/seam_client/client_multi_workspace_spec.rb
+++ b/spec/seam_client/client_multi_workspace_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Seam::ClientMultiWorkspace do
   let(:personal_access_token) { "seam_at_12345" }
   let(:endpoint) { "https://example.com/api" }
-  let(:client) { described_class.from_personal_access_token(personal_access_token, endpoint: endpoint) }
+  let(:client) { described_class.from_personal_access_token(personal_access_token: personal_access_token, endpoint: endpoint) }
 
   describe ".from_personal_access_token" do
     it "creates a new instance with the given token and endpoint" do
@@ -39,10 +39,10 @@ RSpec.describe Seam::ClientMultiWorkspace do
 
   describe "token format validation" do
     it "raises SeamInvalidTokenError for invalid token formats" do
-      expect { described_class.from_personal_access_token("invalid_token") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
-      expect { described_class.from_personal_access_token("seam_apikey_token") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
-      expect { described_class.from_personal_access_token("seam_cst") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
-      expect { described_class.from_personal_access_token("ey") }.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
+      expect { described_class.from_personal_access_token(personal_access_token: "invalid_token") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
+      expect { described_class.from_personal_access_token(personal_access_token: "seam_apikey_token") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
+      expect { described_class.from_personal_access_token(personal_access_token: "seam_cst") }.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
+      expect { described_class.from_personal_access_token(personal_access_token: "ey") }.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
     end
   end
 end

--- a/spec/seam_client/env_spec.rb
+++ b/spec/seam_client/env_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Seam::Client do
     it "uses SEAM_ENDPOINT environment variable with from_api_key" do
       ENV["SEAM_API_URL"] = "https://example.com"
       ENV["SEAM_ENDPOINT"] = Seam::DEFAULT_ENDPOINT
-      seam = Seam::Client.from_api_key("seam_some_api_key")
+      seam = Seam::Client.from_api_key(api_key: "seam_some_api_key")
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -85,8 +85,8 @@ RSpec.describe Seam::Client do
       ENV["SEAM_API_KEY"] = "seam_some_api_key"
 
       seam = Seam::Client.from_personal_access_token(
-        "seam_at1_token",
-        "workspace_123"
+        personal_access_token: "seam_at1_token",
+        workspace_id: "workspace_123"
       )
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})

--- a/spec/seam_client/personal_access_token_spec.rb
+++ b/spec/seam_client/personal_access_token_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe Seam::Client do
   describe "#from_personal_access_token" do
     it "raises error for invalid personal access token formats" do
       expect do
-        Seam::Client.from_personal_access_token("some-invalid-key-format", workspace_id)
+        Seam::Client.from_personal_access_token(personal_access_token: "some-invalid-key-format", workspace_id: workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_personal_access_token("seam_apikey_token", workspace_id)
+        Seam::Client.from_personal_access_token(personal_access_token: "seam_apikey_token", workspace_id: workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_personal_access_token("seam_cst", workspace_id)
+        Seam::Client.from_personal_access_token(personal_access_token: "seam_cst", workspace_id: workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
 
       expect do
-        Seam::Client.from_personal_access_token("ey", workspace_id)
+        Seam::Client.from_personal_access_token(personal_access_token: "ey", workspace_id: workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
     end
   end


### PR DESCRIPTION
closes https://github.com/seamapi/ruby-next/issues/85

- **Client factory methods should accept keyword-only args**
- **ClientMultiWorkspace factory methods should accept keyword-only args**
- **Fix tests**
