### PR TITLE
fix: Bump SDK generator to 1.14.12, fix tests

### DIFF
--- a/lib/seam/routes/clients/devices.rb
+++ b/lib/seam/routes/clients/devices.rb
@@ -28,8 +28,8 @@ module Seam
         Seam::Resources::Device.load_from_response(res.body["device"])
       end
 
-      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
-        res = @client.post("/devices/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
+      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_type: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
+        res = @client.post("/devices/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_type: device_type, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
 
         Seam::Resources::Device.load_from_response(res.body["devices"])
       end

--- a/lib/seam/routes/clients/devices_unmanaged.rb
+++ b/lib/seam/routes/clients/devices_unmanaged.rb
@@ -14,8 +14,8 @@ module Seam
         Seam::Resources::UnmanagedDevice.load_from_response(res.body["device"])
       end
 
-      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
-        res = @client.post("/devices/unmanaged/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
+      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_type: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
+        res = @client.post("/devices/unmanaged/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_type: device_type, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
 
         Seam::Resources::UnmanagedDevice.load_from_response(res.body["devices"])
       end

--- a/lib/seam/routes/clients/locks.rb
+++ b/lib/seam/routes/clients/locks.rb
@@ -16,8 +16,8 @@ module Seam
         Seam::Resources::Device.load_from_response(res.body["device"])
       end
 
-      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
-        res = @client.post("/locks/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
+      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_type: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
+        res = @client.post("/locks/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_type: device_type, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
 
         Seam::Resources::Device.load_from_response(res.body["devices"])
       end

--- a/lib/seam/routes/clients/noise_sensors.rb
+++ b/lib/seam/routes/clients/noise_sensors.rb
@@ -16,8 +16,8 @@ module Seam
         @simulate ||= Seam::Clients::NoiseSensorsSimulate.new(client: @client, defaults: @defaults)
       end
 
-      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
-        res = @client.post("/noise_sensors/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
+      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_type: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
+        res = @client.post("/noise_sensors/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_type: device_type, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
 
         Seam::Resources::Device.load_from_response(res.body["devices"])
       end

--- a/lib/seam/routes/clients/thermostats.rb
+++ b/lib/seam/routes/clients/thermostats.rb
@@ -64,8 +64,8 @@ module Seam
         Helpers::ActionAttempt.decide_and_wait(Seam::Resources::ActionAttempt.load_from_response(res.body["action_attempt"]), @client, wait_for_action_attempt)
       end
 
-      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
-        res = @client.post("/thermostats/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
+      def list(connect_webview_id: nil, connected_account_id: nil, connected_account_ids: nil, created_before: nil, custom_metadata_has: nil, device_ids: nil, device_type: nil, device_types: nil, exclude_if: nil, include_if: nil, limit: nil, manufacturer: nil, user_identifier_key: nil)
+        res = @client.post("/thermostats/list", {connect_webview_id: connect_webview_id, connected_account_id: connected_account_id, connected_account_ids: connected_account_ids, created_before: created_before, custom_metadata_has: custom_metadata_has, device_ids: device_ids, device_type: device_type, device_types: device_types, exclude_if: exclude_if, include_if: include_if, limit: limit, manufacturer: manufacturer, user_identifier_key: user_identifier_key}.compact)
 
         Seam::Resources::Device.load_from_response(res.body["devices"])
       end

--- a/lib/seam/routes/routes.rb
+++ b/lib/seam/routes/routes.rb
@@ -66,10 +66,6 @@ module Seam
       @workspaces ||= Seam::Clients::Workspaces.new(client: @client, defaults: @defaults)
     end
 
-    def health
-      @client.get("/health")
-    end
-
     # @deprecated Please use {#devices.unmanaged} instead.
     def unmanaged_devices
       warn "[DEPRECATION] 'unmanaged_devices' is deprecated. Please use 'devices.unmanaged' instead."

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@seamapi/ruby",
       "devDependencies": {
         "@seamapi/fake-seam-connect": "1.72.1",
-        "@seamapi/nextlove-sdk-generator": "1.14.10",
+        "@seamapi/nextlove-sdk-generator": "1.14.12",
         "@seamapi/types": "1.286.1",
         "del": "^7.1.0",
         "markdown-toc": "^1.2.0",
@@ -454,10 +454,11 @@
       }
     },
     "node_modules/@seamapi/nextlove-sdk-generator": {
-      "version": "1.14.10",
-      "resolved": "https://registry.npmjs.org/@seamapi/nextlove-sdk-generator/-/nextlove-sdk-generator-1.14.10.tgz",
-      "integrity": "sha512-kqNRJZ/+rNQpdcIo8mI0T20kf730P42SSL9r5hh23IObjd2+Z+bKaWTxsHjVbjlwQrhR4cKmR//xfr/7wx2ZCQ==",
+      "version": "1.14.12",
+      "resolved": "https://registry.npmjs.org/@seamapi/nextlove-sdk-generator/-/nextlove-sdk-generator-1.14.12.tgz",
+      "integrity": "sha512-1bSYQ9b8+ezkbfZbAgK6A2XyAKUK5jJrtwpNdVtZpnqzsueiOdOUBoFmoHgd4aHyUISr9uhXc5P8OzuFWsS3Gw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.walk": "^2.0.0",
         "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@seamapi/fake-seam-connect": "1.72.1",
-    "@seamapi/nextlove-sdk-generator": "1.14.10",
+    "@seamapi/nextlove-sdk-generator": "1.14.12",
     "@seamapi/types": "1.286.1",
     "del": "^7.1.0",
     "markdown-toc": "^1.2.0",

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Seam::Http do
 
       before do
         stub_seam_request(
-          :get,
-          "/health",
+          :post,
+          "/devices/list",
           {error: error},
           status: 400,
           headers: {"seam-request-id" => request_id}
@@ -21,7 +21,7 @@ RSpec.describe Seam::Http do
       end
 
       it "parses the error" do
-        expect { client.health }.to raise_error do |error|
+        expect { client.devices.list }.to raise_error do |error|
           expect(error).to be_a(Seam::Http::ApiError)
           expect(error.message).to eq(message)
           expect(error.code).to eq(type)
@@ -38,8 +38,8 @@ RSpec.describe Seam::Http do
 
       before do
         stub_seam_request(
-          :get,
-          "/health",
+          :post,
+          "/devices/list",
           {error: error},
           status: 409,
           headers: {"seam-request-id" => request_id}
@@ -47,7 +47,7 @@ RSpec.describe Seam::Http do
       end
 
       it "parses the error" do
-        expect { client.health }.to raise_error do |error|
+        expect { client.devices.list }.to raise_error do |error|
           expect(error).to be_a(Seam::Http::ApiError)
           expect(error.message).to eq(message)
           expect(error.code).to eq(type)


### PR DESCRIPTION
- Bumps SDK generator to 1.14.12 and fixes tests
- Closes https://github.com/seamapi/ruby/issues/168