### PR TITLE
fix: Avoid wrapping empty hash resource values in DeepHashAccessor

### DIFF
--- a/lib/seam/base_resource.rb
+++ b/lib/seam/base_resource.rb
@@ -11,19 +11,12 @@ module Seam
       def initialize(data, client = nil)
         @data = data
         @client = client
-
-        @data.each do |key, value|
-          value = Seam::DeepHashAccessor.new(value) if value.is_a?(Hash)
-          instance_variable_set(:"@#{key}", value)
-        end
+        process_data_attributes(@data)
       end
 
       def update_from_response(data)
         @data = data
-        @data.each do |key, value|
-          value = Seam::DeepHashAccessor.new(value) if value.is_a?(Hash)
-          instance_variable_set(:"@#{key}", value)
-        end
+        process_data_attributes(@data)
       end
 
       def self.load_from_response(data, client = nil)
@@ -59,6 +52,21 @@ module Seam
 
       def parse_datetime(value)
         Time.parse(value)
+      end
+
+      def process_data_attributes(data)
+        data.each do |key, value|
+          value = process_hash_value(value)
+          instance_variable_set(:"@#{key}", value)
+        end
+      end
+
+      def process_hash_value(value)
+        if value.is_a?(Hash) && !value.empty?
+          Seam::DeepHashAccessor.new(value)
+        else
+          value
+        end
       end
     end
   end

--- a/spec/resources/deep_hash_accessor_spec.rb
+++ b/spec/resources/deep_hash_accessor_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Seam::Resources::BaseResource do
+  describe "hash handling" do
+    let(:client) { Seam.new(api_key: "seam_some_api_key") }
+
+    it "does not wrap empty hashes in DeepHashAccessor" do
+      data = {
+        device_id: "123",
+        empty_hash: {},
+        non_empty_hash: {key: "value"}
+      }
+
+      resource = described_class.new(data, client)
+
+      expect(resource.instance_variable_get(:@empty_hash)).to eq({})
+      expect(resource.instance_variable_get(:@empty_hash)).to be_a(Hash)
+      expect(resource.instance_variable_get(:@empty_hash)).not_to be_a(Seam::DeepHashAccessor)
+
+      expect(resource.instance_variable_get(:@non_empty_hash)).to be_a(Seam::DeepHashAccessor)
+    end
+  end
+end


### PR DESCRIPTION
wrt https://hello-seam.slack.com/archives/C07DTP6EGBZ/p1733811018563499