### PR TITLE
test: restore coverage lost in #537

### DIFF
--- a/spec/deep_hash_accessor_spec.rb
+++ b/spec/deep_hash_accessor_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Seam::DeepHashAccessor do
         city: "San Francisco",
         country: "USA"
       },
-      hobbies: %w[reading cycling]
+      hobbies: %w[reading cycling],
+      pets: [{name: "Rex", species: "dog"}]
     }
   end
 
@@ -35,6 +36,11 @@ RSpec.describe Seam::DeepHashAccessor do
   describe "array handling" do
     it "returns arrays as is for simple types" do
       expect(accessor.hobbies).to eq(%w[reading cycling])
+    end
+
+    it "wraps hashes inside arrays" do
+      expect(accessor.pets.first).to be_a(described_class)
+      expect(accessor.pets.first.name).to eq("Rex")
     end
   end
 

--- a/spec/resources/resource_errors_spec.rb
+++ b/spec/resources/resource_errors_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe "resource errors and warnings" do
+  describe Seam::Resources::ResourceErrorsSupport do
+    it "converts error hashes into ResourceError objects" do
+      device = Seam::Resources::Device.load_from_response(
+        "device_id" => "device_id_1234",
+        "errors" => [
+          {
+            "error_code" => "device_removed",
+            "message" => "Device was removed",
+            "created_at" => "2024-01-01T00:00:00Z"
+          }
+        ]
+      )
+
+      error = device.errors.first
+      expect(error).to be_a(Seam::Resources::ResourceError)
+      expect(error.error_code).to eq("device_removed")
+      expect(error.message).to eq("Device was removed")
+      expect(error.created_at).to be_a(Time)
+    end
+
+    it "returns an empty array when the resource has no errors" do
+      device = Seam::Resources::Device.load_from_response("device_id" => "device_id_1234")
+
+      expect(device.errors).to eq([])
+    end
+  end
+
+  describe Seam::Resources::ResourceWarningsSupport do
+    it "converts warning hashes into ResourceWarning objects" do
+      device = Seam::Resources::Device.load_from_response(
+        "device_id" => "device_id_1234",
+        "warnings" => [
+          {
+            "warning_code" => "privacy_mode",
+            "message" => "Device is in privacy mode",
+            "created_at" => "2024-01-01T00:00:00Z"
+          }
+        ]
+      )
+
+      warning = device.warnings.first
+      expect(warning).to be_a(Seam::Resources::ResourceWarning)
+      expect(warning.warning_code).to eq("privacy_mode")
+      expect(warning.message).to eq("Device is in privacy mode")
+      expect(warning.created_at).to be_a(Time)
+    end
+
+    it "returns an empty array when the resource has no warnings" do
+      device = Seam::Resources::Device.load_from_response("device_id" => "device_id_1234")
+
+      expect(device.warnings).to eq([])
+    end
+  end
+end

--- a/spec/seam_client/malformed_response_spec.rb
+++ b/spec/seam_client/malformed_response_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# The fake cannot produce malformed error responses, so WebMock drives the
+# bodies that must fall through seam_api_error_response? to Faraday's own
+# error handling rather than being parsed into a Seam::Http::ApiError.
+RSpec.describe Seam::Http::Request do
+  let(:seam) { Seam.new(api_key: "seam_some_api_key") }
+  let(:url) { "#{Seam::DEFAULT_ENDPOINT}/devices/list" }
+
+  describe "non-Seam error responses" do
+    it "raises a Faraday error for a plain text response" do
+      stub_request(:post, url).to_return(
+        status: 500,
+        body: "Internal Server Error",
+        headers: {"Content-Type" => "text/plain"}
+      )
+
+      expect { seam.devices.list }.to raise_error(Faraday::ServerError)
+    end
+
+    it "raises a Faraday error for malformed JSON" do
+      stub_request(:post, url).to_return(
+        status: 500,
+        body: "{invalid json",
+        headers: {"Content-Type" => "application/json"}
+      )
+
+      expect { seam.devices.list }.to raise_error(Faraday::ServerError)
+    end
+
+    it "raises a Faraday error for JSON without an error object" do
+      stub_request(:post, url).to_return(
+        status: 500,
+        body: {message: "Some error"}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+
+      expect { seam.devices.list }.to raise_error(Faraday::ServerError)
+    end
+
+    it "raises a Faraday error for an error object without a type and message" do
+      stub_request(:post, url).to_return(
+        status: 500,
+        body: {error: {code: 500}}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+
+      expect { seam.devices.list }.to raise_error(Faraday::ServerError)
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #537. After it merged, I audited every deleted spec assertion against what remains on `main` and found two places where real SDK behavior lost its only coverage. This restores both — specs only, no SDK changes.

## What the audit found

**1. Malformed error response handling** (`spec/seam_client/malformed_response_spec.rb`)

#537 deleted `spec/seam_client/request_spec.rb` claiming its coverage was folded into `http_error_spec` against the fake. That was only partly true. The fake's simulated outage responds with a bare 503 — no content type, empty body — so of the branches in `seam_api_error_response?` only the content-type guard stayed covered. Three fall-through paths lost their specs:

- malformed JSON with a JSON content type (`rescue JSON::ParserError`)
- a JSON body without an `error` object
- an `error` object without string `type` and `message` fields

Restored with WebMock, which is the right tool here for the same reason it backs the headers and retry specs: the fake cannot produce these responses.

**2. Resource error and warning coercion** (`spec/resources/resource_errors_spec.rb`)

#537 deleted the per-route client specs as generated-code tests, but three of them (`devices_spec`, `access_codes_spec`, `connected_accounts_spec`) were the only coverage of `ResourceErrorsSupport` and `ResourceWarningsSupport` — the modules that convert error/warning hashes into `ResourceError` / `ResourceWarning` objects with parsed `created_at` dates. Codegen marks these as hand-maintained (“durable”) static files, so they are SDK behavior, not generated code. After #537: zero assertions on `.errors.first.error_code` anywhere in the suite.

Restored at the resource level where the behavior lives, including the `[]` default when a resource carries no errors or warnings, plus a small `DeepHashAccessor` example for hashes inside arrays, which those specs exercised indirectly.

## One correction to the #537 description

#537 said the deleted action-attempt resource spec “stubbed `:get` on `/action_attempts/get` while the SDK POSTs to it.” That was wrong: `Helpers::ActionAttempt.update_action_attempt` does use `client.get`, so the old stub was consistent with the helper. No coverage was lost there — the wait specs exercise the same path against the fake — but the stated justification was incorrect.

## Verification

```
86 examples, 0 failures
```

Up from 77 on `main`: +4 malformed response, +4 resource errors/warnings, +1 accessor. `rake lint` is clean.

The Python SDK never had the malformed-response coverage either; seamapi/python#599 adds it there for parity.