### PR TITLE
Fix DeepHashAccessor#[] and generate typed nested resource classes

### DIFF
--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -2,6 +2,29 @@
 
 module Seam
   module Resources
+{{#each nestedClasses}}
+    class {{className}} < BaseResource
+{{#each accessors}}
+{{#if description}}
+{{{rubyDoc description 6}}}
+{{/if}}
+      attr_accessor :{{name}}
+{{/each}}
+{{#each dateAccessors}}
+{{#if description}}
+{{{rubyDoc description 6}}}
+{{/if}}
+      date_accessor :{{name}}
+{{/each}}
+{{#each resourceAccessors}}
+      resource_accessor :{{name}}, {{className}}
+{{/each}}
+{{#each resourceListAccessors}}
+      resource_list_accessor :{{name}}, {{className}}
+{{/each}}
+    end
+
+{{/each}}
 {{#if resource.description}}
 {{{rubyDoc resource.description 4}}}
 {{/if}}
@@ -9,6 +32,12 @@ module Seam
 {{{rubyDeprecatedDoc resource 4}}}
 {{/if}}
     class {{className}} < BaseResource
+{{#each resourceAccessors}}
+      resource_accessor :{{name}}, {{className}}
+{{/each}}
+{{#each resourceListAccessors}}
+      resource_list_accessor :{{name}}, {{className}}
+{{/each}}
 {{#each accessors}}
 {{#if description}}
 {{{rubyDoc description 6}}}

--- a/codegen/lib/layouts/resource.ts
+++ b/codegen/lib/layouts/resource.ts
@@ -5,6 +5,17 @@ import type { Property } from '@seamapi/blueprint'
 import { pascalCase } from 'change-case'
 
 import { convertCustomResourceName } from '../custom-resource-name-conversions.js'
+import { mergeProperties } from '../merge-properties.js'
+
+type ResourceAccessor = Property & Documented & { className: string }
+
+interface NestedClass {
+  className: string
+  accessors: Array<Property & Documented>
+  dateAccessors: Array<Property & Documented>
+  resourceAccessors: ResourceAccessor[]
+  resourceListAccessors: ResourceAccessor[]
+}
 
 export interface ResourceLayoutContext {
   className: string
@@ -14,6 +25,9 @@ export interface ResourceLayoutContext {
   hasSupportModules: boolean
   includeErrorsSupport: boolean
   includeWarningsSupport: boolean
+  nestedClasses: NestedClass[]
+  resourceAccessors: ResourceAccessor[]
+  resourceListAccessors: ResourceAccessor[]
 }
 
 interface Documented {
@@ -44,11 +58,82 @@ export const setResourceLayoutContext = (
   const includeErrorsSupport = attrs.includes('errors')
   const includeWarningsSupport = attrs.includes('warnings')
 
+  const rootClassName = pascalCase(convertCustomResourceName(snakeName))
+  const nestedClasses = new Map<string, NestedClass>()
+
+  const buildClass = (
+    className: string,
+    classProperties: Property[],
+  ): NestedClass => {
+    const resourceAccessors: ResourceAccessor[] = []
+    const resourceListAccessors: ResourceAccessor[] = []
+
+    for (const property of classProperties) {
+      if (property.name === 'errors' || property.name === 'warnings') continue
+
+      let nestedProperties: Property[] | undefined
+      let destination = resourceAccessors
+      if (property.format === 'object') {
+        nestedProperties = property.properties
+      } else if (
+        property.format === 'list' &&
+        property.itemFormat === 'object'
+      ) {
+        nestedProperties = property.itemProperties
+        destination = resourceListAccessors
+      } else if (
+        property.format === 'list' &&
+        property.itemFormat === 'discriminated_object'
+      ) {
+        nestedProperties = mergeProperties(
+          property.variants.map((variant) => variant.properties),
+        )
+        destination = resourceListAccessors
+      }
+
+      if (nestedProperties == null) continue
+      const nestedClassName = `${rootClassName}${pascalCase(property.name)}`
+      destination.push({ ...property, className: nestedClassName })
+      if (!nestedClasses.has(nestedClassName)) {
+        const nestedClass = buildClass(nestedClassName, nestedProperties)
+        nestedClasses.set(nestedClassName, nestedClass)
+      }
+    }
+
+    const typedNames = new Set(
+      [...resourceAccessors, ...resourceListAccessors].map(({ name }) => name),
+    )
+    return {
+      className,
+      accessors: classProperties.filter(
+        (property) =>
+          property.format !== 'datetime' && !typedNames.has(property.name),
+      ),
+      dateAccessors: classProperties.filter(
+        (property) => property.format === 'datetime',
+      ),
+      resourceAccessors,
+      resourceListAccessors,
+    }
+  }
+
+  const parentClass = buildClass(rootClassName, properties)
+  const parentTypedNames = new Set(
+    [
+      ...parentClass.resourceAccessors,
+      ...parentClass.resourceListAccessors,
+    ].map(({ name }) => name),
+  )
+
   return {
-    className: pascalCase(convertCustomResourceName(snakeName)),
+    className: rootClassName,
     resource,
     accessors: properties
-      .filter((property) => noErrorWarningAttrs.includes(property.name))
+      .filter(
+        (property) =>
+          noErrorWarningAttrs.includes(property.name) &&
+          !parentTypedNames.has(property.name),
+      )
       .map((property) => property),
     dateAccessors: properties
       .filter((property) => dateAttrs.includes(property.name))
@@ -56,5 +141,8 @@ export const setResourceLayoutContext = (
     hasSupportModules: includeErrorsSupport || includeWarningsSupport,
     includeErrorsSupport,
     includeWarningsSupport,
+    nestedClasses: [...nestedClasses.values()],
+    resourceAccessors: parentClass.resourceAccessors,
+    resourceListAccessors: parentClass.resourceListAccessors,
   }
 }

--- a/codegen/lib/merge-properties.ts
+++ b/codegen/lib/merge-properties.ts
@@ -1,0 +1,11 @@
+import type { Property } from '@seamapi/blueprint'
+
+export const mergeProperties = (propertyLists: Property[][]): Property[] => {
+  const merged = new Map<string, Property>()
+  for (const properties of propertyLists) {
+    for (const property of properties) {
+      if (!merged.has(property.name)) merged.set(property.name, property)
+    }
+  }
+  return [...merged.values()].sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/codegen/lib/routes.ts
+++ b/codegen/lib/routes.ts
@@ -21,6 +21,7 @@ import { setClientLayoutContext } from './layouts/client.js'
 import { setImportsLayoutContext } from './layouts/imports.js'
 import { setResourceLayoutContext } from './layouts/resource.js'
 import { setRoutesFileLayoutContext } from './layouts/routes-file.js'
+import { mergeProperties } from './merge-properties.js'
 import type { ClientMethod, ClientModel } from './ruby-client.js'
 import {
   resourceErrorRb,
@@ -151,16 +152,6 @@ const getResources = (
   }
 
   return [...resources.entries()].sort(([a], [b]) => a.localeCompare(b))
-}
-
-const mergeProperties = (propertyLists: Property[][]): Property[] => {
-  const merged = new Map<string, Property>()
-  for (const properties of propertyLists) {
-    for (const property of properties) {
-      if (!merged.has(property.name)) merged.set(property.name, property)
-    }
-  }
-  return [...merged.values()].sort((a, b) => a.name.localeCompare(b.name))
 }
 
 interface ClientSource {

--- a/codegen/lib/static-resources.ts
+++ b/codegen/lib/static-resources.ts
@@ -34,6 +34,11 @@ export const resourceErrorsSupportRb = `# frozen_string_literal: true
 module Seam
   module Resources
     module ResourceErrorsSupport
+      def update_from_response(data)
+        @errors_converted = nil
+        super
+      end
+
       def errors
         @errors_converted ||= @errors.is_a?(Array) ? Seam::Resources::ResourceError.load_from_response(@errors) : []
       end
@@ -47,6 +52,11 @@ export const resourceWarningsSupportRb = `# frozen_string_literal: true
 module Seam
   module Resources
     module ResourceWarningsSupport
+      def update_from_response(data)
+        @warnings_converted = nil
+        super
+      end
+
       def warnings
         @warnings_converted ||= @warnings.is_a?(Array) ? Seam::Resources::ResourceWarning.load_from_response(@warnings) : []
       end

--- a/lib/seam/base_resource.rb
+++ b/lib/seam/base_resource.rb
@@ -20,6 +20,8 @@ module Seam
       end
 
       def self.load_from_response(data, client = nil)
+        return nil if data.nil?
+
         if data.is_a?(Array)
           data.map { |d| new(d, client) }
         else
@@ -34,6 +36,31 @@ module Seam
             .filter { |k| k != "data" and k != "client" and respond_to? k }
             .map { |k| "  #{k}=#{send(k).inspect}" }
             .join("\n") + ">"
+      end
+
+      def [](key)
+        name = key.to_s
+        return nil unless respond_to?(name)
+
+        public_send(name)
+      end
+
+      def self.resource_accessor(attr, resource_class)
+        resource_accessors[attr.to_s] = resource_class
+        attr_accessor attr
+      end
+
+      def self.resource_list_accessor(attr, resource_class)
+        resource_list_accessors[attr.to_s] = resource_class
+        attr_accessor attr
+      end
+
+      def self.resource_accessors
+        @resource_accessors ||= {}
+      end
+
+      def self.resource_list_accessors
+        @resource_list_accessors ||= {}
       end
 
       def self.date_accessor(*attrs)
@@ -54,7 +81,17 @@ module Seam
 
       def process_data_attributes(data)
         data.each do |key, value|
-          value = process_hash_value(value)
+          next unless key.to_s.match?(/\A[a-zA-Z_][a-zA-Z0-9_]*\z/)
+
+          resource_class = self.class.resource_accessors[key.to_s]
+          resource_list_class = self.class.resource_list_accessors[key.to_s]
+          value = if resource_class && value.is_a?(Hash)
+            resource_class.load_from_response(value, client)
+          elsif resource_list_class && value.is_a?(Array)
+            resource_list_class.load_from_response(value, client)
+          else
+            process_hash_value(value)
+          end
           instance_variable_set(:"@#{key}", value)
         end
       end

--- a/lib/seam/deep_hash_accessor.rb
+++ b/lib/seam/deep_hash_accessor.rb
@@ -10,7 +10,12 @@ module Seam
     end
 
     def [](key)
-      instance_variable_get(:"@#{key}")
+      # Subscript access is Hash-like and returns nil for unknown keys, while
+      # method access continues to raise NoMethodError.
+      name = key.to_s
+      return nil unless respond_to?(name)
+
+      public_send(name)
     end
 
     def to_h
@@ -21,9 +26,8 @@ module Seam
 
     def create_accessor_methods
       @data.each do |key, value|
-        define_singleton_method(key) do
-          process_value(value)
-        end
+        processed = process_value(value)
+        define_singleton_method(key) { processed }
       end
     end
 

--- a/lib/seam/resources/access_code.rb
+++ b/lib/seam/resources/access_code.rb
@@ -2,6 +2,48 @@
 
 module Seam
   module Resources
+    class AccessCodeDormakabaOracodeMetadata < BaseResource
+      # Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+      attr_accessor :is_cancellable
+      # Indicates whether early check-in is available for this stay.
+      attr_accessor :is_early_checkin_able
+      # Indicates whether the stay can be extended via the Dormakaba Oracode API.
+      attr_accessor :is_extendable
+      # Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+      attr_accessor :is_overridable
+      # Dormakaba Oracode site name associated with this access code.
+      attr_accessor :site_name
+      # Dormakaba Oracode stay ID associated with this access code.
+      attr_accessor :stay_id
+      # Dormakaba Oracode user level ID associated with this access code.
+      attr_accessor :user_level_id
+      # Dormakaba Oracode user level name associated with this access code.
+      attr_accessor :user_level_name
+    end
+
+    class AccessCodeFrom < BaseResource
+      # Previous PIN code.
+      attr_accessor :code
+    end
+
+    class AccessCodeTo < BaseResource
+      # New PIN code.
+      attr_accessor :code
+    end
+
+    class AccessCodePendingMutations < BaseResource
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of setting an access code on the device.
+      attr_accessor :mutation_code
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      # Date and time at which Seam will attempt to program this access code on the device.
+      date_accessor :scheduled_at
+      resource_accessor :from, AccessCodeFrom
+      resource_accessor :to, AccessCodeTo
+    end
+
     # Represents a smart lock [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
     #
     # An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
@@ -12,6 +54,8 @@ module Seam
     #
     # For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
     class AccessCode < BaseResource
+      resource_accessor :dormakaba_oracode_metadata, AccessCodeDormakabaOracodeMetadata
+      resource_list_accessor :pending_mutations, AccessCodePendingMutations
       # Unique identifier for the access code.
       attr_accessor :access_code_id
       # Code used for access. Typically, a numeric or alphanumeric string.
@@ -20,8 +64,6 @@ module Seam
       attr_accessor :common_code_key
       # Unique identifier for the device associated with the access code.
       attr_accessor :device_id
-      # Metadata for a dormakaba Oracode managed access code. Only present for access codes from dormakaba Oracode devices.
-      attr_accessor :dormakaba_oracode_metadata
       # Indicates whether the access code is a backup code.
       attr_accessor :is_backup
       # Indicates whether a backup access code is available for use if the primary access code is lost or compromised.
@@ -40,8 +82,6 @@ module Seam
       attr_accessor :is_waiting_for_code_assignment
       # Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
       attr_accessor :name
-      # Collection of pending mutations for the access code. Indicates changes that Seam is in the process of pushing to the device.
-      attr_accessor :pending_mutations
       # Identifier of the pulled backup access code. Used to associate the pulled backup access code with the original access code.
       attr_accessor :pulled_backup_access_code_id
       # Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/lifecycle-of-access-codes).

--- a/lib/seam/resources/access_grant.rb
+++ b/lib/seam/resources/access_grant.rb
@@ -2,8 +2,50 @@
 
 module Seam
   module Resources
+    class AccessGrantFrom < BaseResource
+      # Previous device IDs where access codes existed.
+      attr_accessor :device_ids
+    end
+
+    class AccessGrantTo < BaseResource
+      # Common code key to ensure PIN code reuse across devices.
+      attr_accessor :common_code_key
+      # New device IDs where access codes should be created.
+      attr_accessor :device_ids
+    end
+
+    class AccessGrantPendingMutations < BaseResource
+      # IDs of the access methods being updated.
+      attr_accessor :access_method_ids
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of updating the spaces (devices) associated with this access grant.
+      attr_accessor :mutation_code
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      resource_accessor :from, AccessGrantFrom
+      resource_accessor :to, AccessGrantTo
+    end
+
+    class AccessGrantRequestedAccessMethods < BaseResource
+      # Specific PIN code to use for this access method. Only applicable when mode is 'code'.
+      attr_accessor :code
+      # IDs of the access methods created for the requested access method.
+      attr_accessor :created_access_method_ids
+      # Display name of the access method.
+      attr_accessor :display_name
+      # Maximum number of times the instant key can be used. Only applicable when mode is 'mobile_key'. Defaults to 1 if not specified.
+      attr_accessor :instant_key_max_use_count
+      # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+      attr_accessor :mode
+      # Date and time at which the requested access method was added to the Access Grant.
+      date_accessor :created_at
+    end
+
     # Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
     class AccessGrant < BaseResource
+      resource_list_accessor :pending_mutations, AccessGrantPendingMutations
+      resource_list_accessor :requested_access_methods, AccessGrantRequestedAccessMethods
       # ID of the Access Grant.
       attr_accessor :access_grant_id
       # Unique key for the access grant within the workspace.
@@ -22,10 +64,6 @@ module Seam
       attr_accessor :location_ids
       # Name of the Access Grant. If not provided, the display name will be computed.
       attr_accessor :name
-      # List of pending mutations for the access grant. This shows updates that are in progress.
-      attr_accessor :pending_mutations
-      # Access methods that the user requested for the Access Grant.
-      attr_accessor :requested_access_methods
       # Reservation key for the access grant.
       attr_accessor :reservation_key
       # IDs of the spaces to which the Access Grant gives access.

--- a/lib/seam/resources/access_method.rb
+++ b/lib/seam/resources/access_method.rb
@@ -2,8 +2,30 @@
 
 module Seam
   module Resources
+    class AccessMethodFrom < BaseResource
+      # Previous device IDs where access was provisioned.
+      attr_accessor :device_ids
+    end
+
+    class AccessMethodTo < BaseResource
+      # New device IDs where access is being provisioned.
+      attr_accessor :device_ids
+    end
+
+    class AccessMethodPendingMutations < BaseResource
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of provisioning access for this access method on new devices.
+      attr_accessor :mutation_code
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      resource_accessor :from, AccessMethodFrom
+      resource_accessor :to, AccessMethodTo
+    end
+
     # Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
     class AccessMethod < BaseResource
+      resource_list_accessor :pending_mutations, AccessMethodPendingMutations
       # ID of the access method.
       attr_accessor :access_method_id
       # Token of the client session associated with the access method.
@@ -28,8 +50,6 @@ module Seam
       attr_accessor :is_ready_for_encoding
       # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       attr_accessor :mode
-      # Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
-      attr_accessor :pending_mutations
       # ID of the Seam workspace associated with the access method.
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/acs_access_group.rb
+++ b/lib/seam/resources/acs_access_group.rb
@@ -2,18 +2,50 @@
 
 module Seam
   module Resources
+    class AcsAccessGroupAccessSchedule < BaseResource
+      # Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :ends_at
+      # Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :starts_at
+    end
+
+    class AcsAccessGroupFrom < BaseResource
+      # Name of the access group.
+      attr_accessor :name
+    end
+
+    class AcsAccessGroupTo < BaseResource
+      # Name of the access group.
+      attr_accessor :name
+    end
+
+    class AcsAccessGroupPendingMutations < BaseResource
+      # ID of the user involved in the scheduled change.
+      attr_accessor :acs_user_id
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of pushing an access group creation to the integrated access system.
+      attr_accessor :mutation_code
+      # Whether the user is scheduled to be added to or removed from this access group.
+      attr_accessor :variant
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      resource_accessor :from, AcsAccessGroupFrom
+      resource_accessor :to, AcsAccessGroupTo
+    end
+
     # Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
     #
     # Some access control systems use [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
     #
     # To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
     class AcsAccessGroup < BaseResource
+      resource_accessor :access_schedule, AcsAccessGroupAccessSchedule
+      resource_list_accessor :pending_mutations, AcsAccessGroupPendingMutations
       # @deprecated Use `external_type`.
       attr_accessor :access_group_type
       # @deprecated Use `external_type_display_name`.
       attr_accessor :access_group_type_display_name
-      # `starts_at` and `ends_at` timestamps for the access group's access.
-      attr_accessor :access_schedule
       # ID of the access group.
       attr_accessor :acs_access_group_id
       # ID of the access control system that contains the access group.
@@ -30,8 +62,6 @@ module Seam
       attr_accessor :is_managed
       # Name of the access group.
       attr_accessor :name
-      # Collection of pending mutations for the access group. Represents operations that have been requested but not yet completed on the integrated access system.
-      attr_accessor :pending_mutations
       # ID of the workspace that contains the access group.
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/acs_credential.rb
+++ b/lib/seam/resources/acs_credential.rb
@@ -2,6 +2,40 @@
 
 module Seam
   module Resources
+    class AcsCredentialAssaAbloyVostioMetadata < BaseResource
+      # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+      attr_accessor :auto_join
+      # Names of the doors to which to grant access in the Vostio access system.
+      attr_accessor :door_names
+      # Endpoint ID in the Vostio access system.
+      attr_accessor :endpoint_id
+      # Key ID in the Vostio access system.
+      attr_accessor :key_id
+      # Key issuing request ID in the Vostio access system.
+      attr_accessor :key_issuing_request_id
+      # IDs of the guest entrances to override in the Vostio access system.
+      attr_accessor :override_guest_acs_entrance_ids
+    end
+
+    class AcsCredentialVisionlineMetadata < BaseResource
+      # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+      attr_accessor :auto_join
+      # Card function type in the Visionline access system.
+      attr_accessor :card_function_type
+      # ID of the card in the Visionline access system.
+      attr_accessor :card_id
+      # Common entrance IDs in the Visionline access system.
+      attr_accessor :common_acs_entrance_ids
+      # ID of the credential in the Visionline access system.
+      attr_accessor :credential_id
+      # Guest entrance IDs in the Visionline access system.
+      attr_accessor :guest_acs_entrance_ids
+      # Indicates whether the credential is valid.
+      attr_accessor :is_valid
+      # IDs of the credentials to which you want to join.
+      attr_accessor :joiner_acs_credential_ids
+    end
+
     # Means by which an [access control system user](https://docs.seam.co/low-level-apis/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
     #
     # An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
@@ -10,6 +44,8 @@ module Seam
     #
     # For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach. Use the lower-level ACS credential API directly only when you specifically need to manage individual credentials.
     class AcsCredential < BaseResource
+      resource_accessor :assa_abloy_vostio_metadata, AcsCredentialAssaAbloyVostioMetadata
+      resource_accessor :visionline_metadata, AcsCredentialVisionlineMetadata
       # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       attr_accessor :access_method
       # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
@@ -20,8 +56,6 @@ module Seam
       attr_accessor :acs_system_id
       # ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
       attr_accessor :acs_user_id
-      # Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-      attr_accessor :assa_abloy_vostio_metadata
       # Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
       attr_accessor :card_number
       # Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
@@ -52,8 +86,6 @@ module Seam
       attr_accessor :starts_at
       # ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
       attr_accessor :user_identity_id
-      # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-      attr_accessor :visionline_metadata
       # ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/acs_entrance.rb
+++ b/lib/seam/resources/acs_entrance.rb
@@ -2,22 +2,160 @@
 
 module Seam
   module Resources
+    class AcsEntranceActions < BaseResource
+      # ID of the gadget action.
+      attr_accessor :id
+      # Name of the gadget action.
+      attr_accessor :name
+    end
+
+    class AcsEntranceAkilesMetadata < BaseResource
+      # ID of the Akiles gadget.
+      attr_accessor :gadget_id
+      # ID of the Akiles site the gadget belongs to.
+      attr_accessor :site_id
+      # Name of the Akiles site the gadget belongs to.
+      attr_accessor :site_name
+      resource_list_accessor :actions, AcsEntranceActions
+    end
+
+    class AcsEntranceAssaAbloyVostioMetadata < BaseResource
+      # Name of the door in the Vostio access system.
+      attr_accessor :door_name
+      # Number of the door in the Vostio access system.
+      attr_accessor :door_number
+      # Type of the door in the Vostio access system.
+      attr_accessor :door_type
+      # PMS ID of the door in the Vostio access system.
+      attr_accessor :pms_id
+      # Indicates whether keys are allowed to set the door in stand open mode in the Vostio access system.
+      attr_accessor :stand_open
+    end
+
+    class AcsEntranceAvigilonAltaMetadata < BaseResource
+      # Entry name for an Avigilon Alta system.
+      attr_accessor :entry_name
+      # Total count of entry relays for an Avigilon Alta system.
+      attr_accessor :entry_relays_total_count
+      # Organization name for an Avigilon Alta system.
+      attr_accessor :org_name
+      # Site ID for an Avigilon Alta system.
+      attr_accessor :site_id
+      # Site name for an Avigilon Alta system.
+      attr_accessor :site_name
+      # Zone ID for an Avigilon Alta system.
+      attr_accessor :zone_id
+      # Zone name for an Avigilon Alta system.
+      attr_accessor :zone_name
+    end
+
+    class AcsEntranceBrivoMetadata < BaseResource
+      # ID of the access point in the Brivo access system.
+      attr_accessor :access_point_id
+      # ID of the site that the access point belongs to.
+      attr_accessor :site_id
+      # Name of the site that the access point belongs to.
+      attr_accessor :site_name
+    end
+
+    class AcsEntranceDormakabaAmbianceMetadata < BaseResource
+      # Name of the access point in the dormakaba Ambiance access system.
+      attr_accessor :access_point_name
+    end
+
+    class AcsEntranceDormakabaCommunityMetadata < BaseResource
+      # Type of access point profile in the dormakaba Community access system.
+      attr_accessor :access_point_profile
+    end
+
+    class AcsEntranceHotekMetadata < BaseResource
+      # Display name of the entrance.
+      attr_accessor :common_area_name
+      # Display name of the entrance.
+      attr_accessor :common_area_number
+      # Room number of the entrance.
+      attr_accessor :room_number
+    end
+
+    class AcsEntranceLatchMetadata < BaseResource
+      # Accessibility type in the Latch access system.
+      attr_accessor :accessibility_type
+      # Name of the door in the Latch access system.
+      attr_accessor :door_name
+      # Type of the door in the Latch access system.
+      attr_accessor :door_type
+      # Indicates whether the entrance is connected.
+      attr_accessor :is_connected
+    end
+
+    class AcsEntranceSaltoKsMetadata < BaseResource
+      # Battery level of the door access device.
+      attr_accessor :battery_level
+      # Name of the door in the Salto KS access system.
+      attr_accessor :door_name
+      # Indicates whether an intrusion alarm is active on the door.
+      attr_accessor :intrusion_alarm
+      # Indicates whether the door is left open.
+      attr_accessor :left_open_alarm
+      # Type of the lock in the Salto KS access system.
+      attr_accessor :lock_type
+      # Locked state of the door in the Salto KS access system.
+      attr_accessor :locked_state
+      # Indicates whether the door access device is online.
+      attr_accessor :online
+      # Indicates whether privacy mode is enabled for the lock.
+      attr_accessor :privacy_mode
+    end
+
+    class AcsEntranceSaltoSpaceMetadata < BaseResource
+      # Indicates whether AuditOnKeys is enabled for the door in the Salto Space access system.
+      attr_accessor :audit_on_keys
+      # Description of the door in the Salto Space access system.
+      attr_accessor :door_description
+      # Door ID in the Salto Space access system.
+      attr_accessor :door_id
+      # Name of the door in the Salto Space access system.
+      attr_accessor :door_name
+      # Description of the room in the Salto Space access system.
+      attr_accessor :room_description
+      # Name of the room in the Salto Space access system.
+      attr_accessor :room_name
+    end
+
+    class AcsEntranceProfiles < BaseResource
+      # Door profile ID in the Visionline access system.
+      attr_accessor :visionline_door_profile_id
+      # Door profile type in the Visionline access system.
+      attr_accessor :visionline_door_profile_type
+    end
+
+    class AcsEntranceVisionlineMetadata < BaseResource
+      # Category of the door in the Visionline access system.
+      attr_accessor :door_category
+      # Name of the door in the Visionline access system.
+      attr_accessor :door_name
+      resource_list_accessor :profiles, AcsEntranceProfiles
+    end
+
     # Represents an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
     #
     # In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
     class AcsEntrance < BaseResource
+      resource_accessor :akiles_metadata, AcsEntranceAkilesMetadata
+      resource_accessor :assa_abloy_vostio_metadata, AcsEntranceAssaAbloyVostioMetadata
+      resource_accessor :avigilon_alta_metadata, AcsEntranceAvigilonAltaMetadata
+      resource_accessor :brivo_metadata, AcsEntranceBrivoMetadata
+      resource_accessor :dormakaba_ambiance_metadata, AcsEntranceDormakabaAmbianceMetadata
+      resource_accessor :dormakaba_community_metadata, AcsEntranceDormakabaCommunityMetadata
+      resource_accessor :hotek_metadata, AcsEntranceHotekMetadata
+      resource_accessor :latch_metadata, AcsEntranceLatchMetadata
+      resource_accessor :salto_ks_metadata, AcsEntranceSaltoKsMetadata
+      resource_accessor :salto_space_metadata, AcsEntranceSaltoSpaceMetadata
+      resource_accessor :visionline_metadata, AcsEntranceVisionlineMetadata
       # ID of the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
       attr_accessor :acs_entrance_id
       # ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
       attr_accessor :acs_system_id
-      # Akiles-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :akiles_metadata
-      # ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :assa_abloy_vostio_metadata
-      # Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :avigilon_alta_metadata
-      # Brivo-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :brivo_metadata
       # Indicates whether the ACS entrance can belong to a reservation via an access_grant.reservation_key.
       attr_accessor :can_belong_to_reservation
       # Indicates whether the ACS entrance can be unlocked with card credentials.
@@ -32,24 +170,10 @@ module Seam
       attr_accessor :connected_account_id
       # Display name for the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
       attr_accessor :display_name
-      # dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :dormakaba_ambiance_metadata
-      # dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :dormakaba_community_metadata
-      # Hotek-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :hotek_metadata
       # Indicates whether the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) is currently locked.
       attr_accessor :is_locked
-      # Latch-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :latch_metadata
-      # Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :salto_ks_metadata
-      # Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :salto_space_metadata
       # IDs of the spaces that the entrance is in.
       attr_accessor :space_ids
-      # Visionline-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
-      attr_accessor :visionline_metadata
 
       # Date and time at which the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was created.
       date_accessor :created_at

--- a/lib/seam/resources/acs_system.rb
+++ b/lib/seam/resources/acs_system.rb
@@ -2,12 +2,28 @@
 
 module Seam
   module Resources
+    class AcsSystemLocation < BaseResource
+      # Time zone in which the [access control system](https://docs.seam.co/low-level-apis/access-systems) is located.
+      attr_accessor :time_zone
+    end
+
+    class AcsSystemVisionlineMetadata < BaseResource
+      # IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) on the local network.
+      attr_accessor :lan_address
+      # Keyset loaded into a reader. Mobile keys and reader administration tools securely authenticate only with readers programmed with a matching keyset.
+      attr_accessor :mobile_access_uuid
+      # Unique ID assigned by the ASSA ABLOY licensing team that identifies each hotel in your credential manager.
+      attr_accessor :system_id
+    end
+
     # Represents an [access control system](https://docs.seam.co/low-level-apis/access-systems).
     #
     # Within an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users/object) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials/object) to grant access to the `acs_user`s.
     #
     # For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
     class AcsSystem < BaseResource
+      resource_accessor :location, AcsSystemLocation
+      resource_accessor :visionline_metadata, AcsSystemVisionlineMetadata
       # Number of access groups in the [access control system](https://docs.seam.co/low-level-apis/access-systems).
       attr_accessor :acs_access_group_count
       # ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
@@ -31,16 +47,12 @@ module Seam
       attr_accessor :image_url
       # Indicates whether the `acs_system` is a credential manager.
       attr_accessor :is_credential_manager
-      # Location information for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
-      attr_accessor :location
       # Name of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
       attr_accessor :name
       # @deprecated Use `external_type`.
       attr_accessor :system_type
       # @deprecated Use `external_type_display_name`.
       attr_accessor :system_type_display_name
-      # Visionline-specific metadata for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
-      attr_accessor :visionline_metadata
       # ID of the workspace that contains the [access control system](https://docs.seam.co/low-level-apis/access-systems).
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/acs_user.rb
+++ b/lib/seam/resources/acs_user.rb
@@ -2,14 +2,70 @@
 
 module Seam
   module Resources
+    class AcsUserAccessSchedule < BaseResource
+      # Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :ends_at
+      # Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :starts_at
+    end
+
+    class AcsUserFrom < BaseResource
+      # Email address of the access system user.
+      attr_accessor :email_address
+      # Full name of the access system user.
+      attr_accessor :full_name
+      # Phone number of the access system user.
+      attr_accessor :phone_number
+    end
+
+    class AcsUserTo < BaseResource
+      # Email address of the access system user.
+      attr_accessor :email_address
+      # Full name of the access system user.
+      attr_accessor :full_name
+      # Phone number of the access system user.
+      attr_accessor :phone_number
+    end
+
+    class AcsUserPendingMutations < BaseResource
+      # ID of the access group involved in the scheduled change.
+      attr_accessor :acs_access_group_id
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of pushing a user creation to the integrated access system.
+      attr_accessor :mutation_code
+      # Whether the user is scheduled to be added to or removed from the access group.
+      attr_accessor :variant
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      # Optional: When the user creation is scheduled to occur.
+      date_accessor :scheduled_at
+      resource_accessor :from, AcsUserFrom
+      resource_accessor :to, AcsUserTo
+    end
+
+    class AcsUserSaltoKsMetadata < BaseResource
+      # Indicates whether the user holds an active subscription slot on the Salto KS site. Only subscribed users can unlock doors and count against the site's user-subscription limit. A user may not be subscribed because their access schedule has not started or has ended, the site has reached its subscription limit, or they were manually unsubscribed. This is distinct from `is_suspended`, which reflects whether the user has been explicitly blocked.
+      attr_accessor :is_subscribed
+    end
+
+    class AcsUserSaltoSpaceMetadata < BaseResource
+      # Indicates whether AuditOpenings is enabled for the user in the Salto Space access system.
+      attr_accessor :audit_openings
+      # User ID in the Salto Space access system.
+      attr_accessor :user_id
+    end
+
     # Represents a [user](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access system](https://docs.seam.co/low-level-apis/access-systems).
     #
     # An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
     #
     # For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
     class AcsUser < BaseResource
-      # `starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/low-level-apis/access-systems/user-management) access.
-      attr_accessor :access_schedule
+      resource_accessor :access_schedule, AcsUserAccessSchedule
+      resource_accessor :salto_ks_metadata, AcsUserSaltoKsMetadata
+      resource_accessor :salto_space_metadata, AcsUserSaltoSpaceMetadata
+      resource_list_accessor :pending_mutations, AcsUserPendingMutations
       # ID of the [access system](https://docs.seam.co/low-level-apis/access-systems) that contains the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
       attr_accessor :acs_system_id
       # ID of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
@@ -34,14 +90,8 @@ module Seam
       attr_accessor :is_managed
       # Indicates whether the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is currently [suspended](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users).
       attr_accessor :is_suspended
-      # Pending mutations associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.
-      attr_accessor :pending_mutations
       # Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
       attr_accessor :phone_number
-      # Salto KS-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
-      attr_accessor :salto_ks_metadata
-      # Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
-      attr_accessor :salto_space_metadata
       # Email address of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
       attr_accessor :user_identity_email_address
       # Full name of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).

--- a/lib/seam/resources/action_attempt.rb
+++ b/lib/seam/resources/action_attempt.rb
@@ -2,16 +2,26 @@
 
 module Seam
   module Resources
+    class ActionAttemptError < BaseResource
+      # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Type of the error.
+      attr_accessor :type
+    end
+
+    class ActionAttemptResult < BaseResource
+      # Indicates whether the device confirmed that the lock action occurred.
+      attr_accessor :was_confirmed_by_device
+    end
+
     # Locking a door is pending.
     class ActionAttempt < BaseResource
+      resource_accessor :error, ActionAttemptError
+      resource_accessor :result, ActionAttemptResult
       # ID of the action attempt.
       attr_accessor :action_attempt_id
       # Action attempt to track the status of locking a door.
       attr_accessor :action_type
-      # Error associated with the action.
-      attr_accessor :error
-      # Result of the action.
-      attr_accessor :result
       attr_accessor :status
     end
   end

--- a/lib/seam/resources/connected_account.rb
+++ b/lib/seam/resources/connected_account.rb
@@ -2,8 +2,22 @@
 
 module Seam
   module Resources
+    class ConnectedAccountUserIdentifier < BaseResource
+      # API URL for the user identifier associated with the connected account.
+      attr_accessor :api_url
+      # Email address of the user identifier associated with the connected account.
+      attr_accessor :email
+      # Indicates whether the user identifier associated with the connected account is exclusive.
+      attr_accessor :exclusive
+      # Phone number of the user identifier associated with the connected account.
+      attr_accessor :phone
+      # Username of the user identifier associated with the connected account.
+      attr_accessor :username
+    end
+
     # Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
     class ConnectedAccount < BaseResource
+      resource_accessor :user_identifier, ConnectedAccountUserIdentifier
       # List of capabilities that were accepted during the account connection process.
       attr_accessor :accepted_capabilities
       # Type of connected account.
@@ -32,9 +46,6 @@ module Seam
       attr_accessor :image_url
       # IANA time zone (e.g. America/Los_Angeles) for this connected account. Sourced from the connector configuration.
       attr_accessor :time_zone
-      # User identifier associated with the connected account.
-      # @deprecated Use `display_name` instead.
-      attr_accessor :user_identifier
 
       # Date and time at which the connected account was created.
       date_accessor :created_at

--- a/lib/seam/resources/device.rb
+++ b/lib/seam/resources/device.rb
@@ -2,8 +2,1041 @@
 
 module Seam
   module Resources
+    class DeviceDeviceManufacturer < BaseResource
+      # Display name for the manufacturer, such as `August`, `Yale`, `Salto`, and so on.
+      attr_accessor :display_name
+      # Image URL for the manufacturer logo.
+      attr_accessor :image_url
+      # Manufacturer identifier, such as `august`, `yale`, `salto`, and so on.
+      attr_accessor :manufacturer
+    end
+
+    class DeviceDeviceProvider < BaseResource
+      # Device provider name. Corresponds to the integration type, such as `august`, `schlage`, `yale_access`, and so on.
+      attr_accessor :device_provider_name
+      # Display name for the device provider type.
+      attr_accessor :display_name
+      # Image URL for the device provider.
+      attr_accessor :image_url
+      # Provider category. Indicates the third-party provider type, such as `stable`, for stable integrations, or `internal`, for internal integrations.
+      attr_accessor :provider_category
+    end
+
+    class DeviceLocation < BaseResource
+      # Name of the device location.
+      attr_accessor :location_name
+      # Time zone of the device location.
+      attr_accessor :time_zone
+      # Time zone of the device location.
+      attr_accessor :timezone
+    end
+
+    class DeviceBattery < BaseResource
+      attr_accessor :level
+    end
+
+    class DeviceAccessoryKeypad < BaseResource
+      # Indicates if an accessory keypad is connected to the device.
+      attr_accessor :is_connected
+      resource_accessor :battery, DeviceBattery
+    end
+
+    class DeviceAppearance < BaseResource
+      # Name of the device as seen from the provider API and application, not settable through Seam.
+      attr_accessor :name
+    end
+
+    class DeviceModel < BaseResource
+      attr_accessor :accessory_keypad_supported
+      # Indicates whether the device can connect a accessory keypad.
+      attr_accessor :can_connect_accessory_keypad
+      # Display name of the device model.
+      attr_accessor :display_name
+      # Indicates whether the device has a built in accessory keypad.
+      attr_accessor :has_built_in_keypad
+      # Display name that corresponds to the manufacturer-specific terminology for the device.
+      attr_accessor :manufacturer_display_name
+      attr_accessor :offline_access_codes_supported
+      attr_accessor :online_access_codes_supported
+    end
+
+    class DeviceEndpoints < BaseResource
+      # ID of the associated endpoint.
+      attr_accessor :endpoint_id
+      # Indicated whether the endpoint is active.
+      attr_accessor :is_active
+    end
+
+    class DeviceAssaAbloyCredentialServiceMetadata < BaseResource
+      # Indicates whether the credential service has active endpoints associated with the phone.
+      attr_accessor :has_active_endpoint
+      resource_list_accessor :endpoints, DeviceEndpoints
+    end
+
+    class DeviceSaltoSpaceCredentialServiceMetadata < BaseResource
+      # Indicates whether the credential service has an active associated phone.
+      attr_accessor :has_active_phone
+    end
+
+    class DeviceAkilesMetadata < BaseResource
+      # Group ID to which to add users for an Akiles device.
+      attr_accessor :_member_group_id
+      # Gadget ID for an Akiles device.
+      attr_accessor :gadget_id
+      # Gadget name for an Akiles device.
+      attr_accessor :gadget_name
+      # Product name for an Akiles device.
+      attr_accessor :product_name
+    end
+
+    class DeviceAqaraMetadata < BaseResource
+      # Device name for an Aqara device.
+      attr_accessor :device_name
+      # Device ID (did) for an Aqara device.
+      attr_accessor :did
+      # Firmware version for an Aqara device.
+      attr_accessor :firmware_version
+      # Model identifier for an Aqara device.
+      attr_accessor :model
+      # Model type for an Aqara device.
+      attr_accessor :model_type
+      # Parent gateway device ID for an Aqara device.
+      attr_accessor :parent_did
+      # Position (room) ID for an Aqara device.
+      attr_accessor :position_id
+      # Time zone reported for an Aqara device (e.g. GMT-07:00).
+      attr_accessor :time_zone
+    end
+
+    class DeviceAssaAbloyVostioMetadata < BaseResource
+      # Encoder name for an ASSA ABLOY Vostio system.
+      attr_accessor :encoder_name
+    end
+
+    class DeviceAugustMetadata < BaseResource
+      # Indicates whether an August device has a keypad.
+      attr_accessor :has_keypad
+      # House ID for an August device.
+      attr_accessor :house_id
+      # House name for an August device.
+      attr_accessor :house_name
+      # Keypad battery level for an August device.
+      attr_accessor :keypad_battery_level
+      # Lock ID for an August device.
+      attr_accessor :lock_id
+      # Lock name for an August device.
+      attr_accessor :lock_name
+      # Model for an August device.
+      attr_accessor :model
+    end
+
+    class DeviceAvigilonAltaMetadata < BaseResource
+      # Entry name for an Avigilon Alta system.
+      attr_accessor :entry_name
+      # Total count of entry relays for an Avigilon Alta system.
+      attr_accessor :entry_relays_total_count
+      # Organization name for an Avigilon Alta system.
+      attr_accessor :org_name
+      # Site ID for an Avigilon Alta system.
+      attr_accessor :site_id
+      # Site name for an Avigilon Alta system.
+      attr_accessor :site_name
+      # Zone ID for an Avigilon Alta system.
+      attr_accessor :zone_id
+      # Zone name for an Avigilon Alta system.
+      attr_accessor :zone_name
+    end
+
+    class DeviceBrivoMetadata < BaseResource
+      # Indicates whether the Brivo access point has activation (remote unlock) enabled.
+      attr_accessor :activation_enabled
+      # Device name for a Brivo device.
+      attr_accessor :device_name
+    end
+
+    class DeviceControlbywebMetadata < BaseResource
+      # Device ID for a ControlByWeb device.
+      attr_accessor :device_id
+      # Device name for a ControlByWeb device.
+      attr_accessor :device_name
+      # Relay name for a ControlByWeb device.
+      attr_accessor :relay_name
+    end
+
+    class DeviceDeviceId < BaseResource
+    end
+
+    class DevicePredefinedTimeSlots < BaseResource
+      # Check in time for a time slot for a dormakaba Oracode device.
+      attr_accessor :check_in_time
+      # Checkout time for a time slot for a dormakaba Oracode device.
+      attr_accessor :check_out_time
+      # ID of a user level for a dormakaba Oracode device.
+      attr_accessor :dormakaba_oracode_user_level_id
+      # Prefix for a user level for a dormakaba Oracode device.
+      attr_accessor :dormakaba_oracode_user_level_prefix
+      # Indicates whether a time slot for a dormakaba Oracode device is a 24-hour time slot.
+      attr_accessor :is_24_hour
+      # Indicates whether a time slot for a dormakaba Oracode device is in biweekly mode.
+      attr_accessor :is_biweekly_mode
+      # Indicates whether a time slot for a dormakaba Oracode device is a master time slot.
+      attr_accessor :is_master
+      # Indicates whether a time slot for a dormakaba Oracode device is a one-shot time slot.
+      attr_accessor :is_one_shot
+      # Name of a time slot for a dormakaba Oracode device.
+      attr_accessor :name
+      # Prefix for a time slot for a dormakaba Oracode device.
+      attr_accessor :prefix
+    end
+
+    class DeviceDormakabaOracodeMetadata < BaseResource
+      # Door ID for a dormakaba Oracode device.
+      attr_accessor :door_id
+      # Indicates whether a door is wireless for a dormakaba Oracode device.
+      attr_accessor :door_is_wireless
+      # Door name for a dormakaba Oracode device.
+      attr_accessor :door_name
+      # IANA time zone for a dormakaba Oracode device.
+      attr_accessor :iana_timezone
+      # Site ID for a dormakaba Oracode device.
+      attr_accessor :site_id
+      # Site name for a dormakaba Oracode device.
+      attr_accessor :site_name
+      resource_accessor :device_id, DeviceDeviceId
+      resource_list_accessor :predefined_time_slots, DevicePredefinedTimeSlots
+    end
+
+    class DeviceEcobeeMetadata < BaseResource
+      # Device name for an ecobee device.
+      attr_accessor :device_name
+      # Device ID for an ecobee device.
+      attr_accessor :ecobee_device_id
+    end
+
+    class DeviceFourSuitesMetadata < BaseResource
+      # Device ID for a 4SUITES device.
+      attr_accessor :device_id
+      # Device name for a 4SUITES device.
+      attr_accessor :device_name
+      # Reclose delay, in seconds, for a 4SUITES device.
+      attr_accessor :reclose_delay_in_seconds
+    end
+
+    class DeviceGenieMetadata < BaseResource
+      # Lock name for a Genie device.
+      attr_accessor :device_name
+      # Door name for a Genie device.
+      attr_accessor :door_name
+    end
+
+    class DeviceHoneywellResideoMetadata < BaseResource
+      # Device name for a Honeywell Resideo device.
+      attr_accessor :device_name
+      # Device ID for a Honeywell Resideo device.
+      attr_accessor :honeywell_resideo_device_id
+    end
+
+    class DeviceIglooMetadata < BaseResource
+      # Bridge ID for an igloo device.
+      attr_accessor :bridge_id
+      # Device ID for an igloo device.
+      attr_accessor :device_id
+      # Model for an igloo device.
+      attr_accessor :model
+    end
+
+    class DeviceIgloohomeMetadata < BaseResource
+      # Bridge ID for an igloohome device.
+      attr_accessor :bridge_id
+      # Bridge name for an igloohome device.
+      attr_accessor :bridge_name
+      # Device ID for an igloohome device.
+      attr_accessor :device_id
+      # Device name for an igloohome device.
+      attr_accessor :device_name
+      # Indicates whether a keypad is linked to a bridge for an igloohome device.
+      attr_accessor :is_accessory_keypad_linked_to_bridge
+      # Keypad ID for an igloohome device.
+      attr_accessor :keypad_id
+    end
+
+    class DeviceKeynestMetadata < BaseResource
+      # Address for a KeyNest device.
+      attr_accessor :address
+      # Current or last store ID for a KeyNest device.
+      attr_accessor :current_or_last_store_id
+      # Current status for a KeyNest device.
+      attr_accessor :current_status
+      # Current user company for a KeyNest device.
+      attr_accessor :current_user_company
+      # Current user email for a KeyNest device.
+      attr_accessor :current_user_email
+      # Current user name for a KeyNest device.
+      attr_accessor :current_user_name
+      # Current user phone number for a KeyNest device.
+      attr_accessor :current_user_phone_number
+      # Default office ID for a KeyNest device.
+      attr_accessor :default_office_id
+      # Device name for a KeyNest device.
+      attr_accessor :device_name
+      # Fob ID for a KeyNest device.
+      attr_accessor :fob_id
+      # Handover method for a KeyNest device.
+      attr_accessor :handover_method
+      # Whether the KeyNest device has a photo.
+      attr_accessor :has_photo
+      # Whether the key is in a locker that does not support the access codes API.
+      attr_accessor :is_quadient_locker
+      # Key ID for a KeyNest device.
+      attr_accessor :key_id
+      # Key notes for a KeyNest device.
+      attr_accessor :key_notes
+      # KeyNest app user for a KeyNest device.
+      attr_accessor :keynest_app_user
+      # Last movement timestamp for a KeyNest device.
+      attr_accessor :last_movement
+      # Property ID for a KeyNest device.
+      attr_accessor :property_id
+      # Property postcode for a KeyNest device.
+      attr_accessor :property_postcode
+      # Status type for a KeyNest device.
+      attr_accessor :status_type
+      # Subscription plan for a KeyNest device.
+      attr_accessor :subscription_plan
+    end
+
+    class DeviceKisiMetadata < BaseResource
+      # Description for a Kisi device.
+      attr_accessor :description
+      # Lock ID for a Kisi device.
+      attr_accessor :lock_id
+      # Lock name for a Kisi device.
+      attr_accessor :lock_name
+      # Place name for a Kisi device.
+      attr_accessor :place_name
+    end
+
+    class DeviceKorelockMetadata < BaseResource
+      # Device ID for a Korelock device.
+      attr_accessor :device_id
+      # Device name for a Korelock device.
+      attr_accessor :device_name
+      # Firmware version for a Korelock device.
+      attr_accessor :firmware_version
+      # Location ID for a Korelock device. Required for timebound access codes.
+      attr_accessor :location_id
+      # Model code for a Korelock device.
+      attr_accessor :model_code
+      # Serial number for a Korelock device.
+      attr_accessor :serial_number
+      # WiFi signal strength (0-1) for a Korelock device.
+      attr_accessor :wifi_signal_strength
+    end
+
+    class DeviceKwiksetMetadata < BaseResource
+      # Device ID for a Kwikset device.
+      attr_accessor :device_id
+      # Device name for a Kwikset device.
+      attr_accessor :device_name
+      # Model number for a Kwikset device.
+      attr_accessor :model_number
+    end
+
+    class DeviceLocklyMetadata < BaseResource
+      # Device ID for a Lockly device.
+      attr_accessor :device_id
+      # Device name for a Lockly device.
+      attr_accessor :device_name
+      # Model for a Lockly device.
+      attr_accessor :model
+    end
+
+    class DeviceAccelerometerZ < BaseResource
+      # Time of latest accelerometer Z-axis reading for a Minut device.
+      attr_accessor :time
+      # Value of latest accelerometer Z-axis reading for a Minut device.
+      attr_accessor :value
+    end
+
+    class DeviceHumidity < BaseResource
+      # Time of latest humidity reading for a Minut device.
+      attr_accessor :time
+      # Value of latest humidity reading for a Minut device.
+      attr_accessor :value
+    end
+
+    class DevicePressure < BaseResource
+      # Time of latest pressure reading for a Minut device.
+      attr_accessor :time
+      # Value of latest pressure reading for a Minut device.
+      attr_accessor :value
+    end
+
+    class DeviceSound < BaseResource
+      # Time of latest sound reading for a Minut device.
+      attr_accessor :time
+      # Value of latest sound reading for a Minut device.
+      attr_accessor :value
+    end
+
+    class DeviceTemperature < BaseResource
+      # Time of latest temperature reading for a Minut device.
+      attr_accessor :time
+      # Value of latest temperature reading for a Minut device.
+      attr_accessor :value
+    end
+
+    class DeviceLatestSensorValues < BaseResource
+      resource_accessor :accelerometer_z, DeviceAccelerometerZ
+      resource_accessor :humidity, DeviceHumidity
+      resource_accessor :pressure, DevicePressure
+      resource_accessor :sound, DeviceSound
+      resource_accessor :temperature, DeviceTemperature
+    end
+
+    class DeviceMinutMetadata < BaseResource
+      # Device ID for a Minut device.
+      attr_accessor :device_id
+      # Device name for a Minut device.
+      attr_accessor :device_name
+      resource_accessor :latest_sensor_values, DeviceLatestSensorValues
+    end
+
+    class DeviceNestMetadata < BaseResource
+      # Custom device name for a Google Nest device. The device owner sets this value.
+      attr_accessor :device_custom_name
+      # Device name for a Google Nest device. Google sets this value.
+      attr_accessor :device_name
+      # Display name for a Google Nest device.
+      attr_accessor :display_name
+      # Device ID for a Google Nest device.
+      attr_accessor :nest_device_id
+    end
+
+    class DeviceNoiseawareMetadata < BaseResource
+      # Device ID for a NoiseAware device.
+      attr_accessor :device_id
+      # Device model for a NoiseAware device.
+      attr_accessor :device_model
+      # Device name for a NoiseAware device.
+      attr_accessor :device_name
+      # Noise level, in decibels, for a NoiseAware device.
+      attr_accessor :noise_level_decibel
+      # Noise level, expressed as a Noise Risk Score (NRS), for a NoiseAware device.
+      attr_accessor :noise_level_nrs
+    end
+
+    class DeviceNukiMetadata < BaseResource
+      # Device ID for a Nuki device.
+      attr_accessor :device_id
+      # Device name for a Nuki device.
+      attr_accessor :device_name
+      # Indicates whether keypad 2 is paired for a Nuki device.
+      attr_accessor :keypad_2_paired
+      # Indicates whether the keypad battery is in a critical state for a Nuki device.
+      attr_accessor :keypad_battery_critical
+      # Indicates whether the keypad is paired for a Nuki device.
+      attr_accessor :keypad_paired
+    end
+
+    class DeviceOmnitecMetadata < BaseResource
+      # Whether the Omnitec lock has a connected gateway for remote operations.
+      attr_accessor :has_gateway
+      # Operator-assigned alias for an Omnitec device.
+      attr_accessor :lock_alias
+      # Lock ID for an Omnitec device.
+      attr_accessor :lock_id
+      # Bluetooth MAC address for an Omnitec device.
+      attr_accessor :lock_mac
+      # Lock name for an Omnitec device.
+      attr_accessor :lock_name
+      # IANA time zone for the Omnitec device, used to schedule time-bound access codes at the correct local time (accounting for DST).
+      attr_accessor :time_zone
+      # Static UTC offset of the Omnitec lock in milliseconds. Does not account for DST.
+      attr_accessor :timezone_raw_offset_ms
+    end
+
+    class DeviceRingMetadata < BaseResource
+      # Device ID for a Ring device.
+      attr_accessor :device_id
+      # Device name for a Ring device.
+      attr_accessor :device_name
+    end
+
+    class DeviceSaltoKsMetadata < BaseResource
+      # Battery level for a Salto KS device.
+      attr_accessor :battery_level
+      # Customer reference for a Salto KS device.
+      attr_accessor :customer_reference
+      # Indicates whether the site has a Salto KS subscription that supports custom PINs.
+      attr_accessor :has_custom_pin_subscription
+      # Lock ID for a Salto KS device.
+      attr_accessor :lock_id
+      # Lock type for a Salto KS device.
+      attr_accessor :lock_type
+      # Locked state for a Salto KS device.
+      attr_accessor :locked_state
+      # Model for a Salto KS device.
+      attr_accessor :model
+      # Site ID for the Salto KS site to which the device belongs.
+      attr_accessor :site_id
+      # Site name for the Salto KS site to which the device belongs.
+      attr_accessor :site_name
+    end
+
+    class DeviceSaltoMetadata < BaseResource
+      # Battery level for a Salto device.
+      attr_accessor :battery_level
+      # Customer reference for a Salto device.
+      attr_accessor :customer_reference
+      # Lock ID for a Salto device.
+      attr_accessor :lock_id
+      # Lock type for a Salto device.
+      attr_accessor :lock_type
+      # Locked state for a Salto device.
+      attr_accessor :locked_state
+      # Model for a Salto device.
+      attr_accessor :model
+      # Site ID for the Salto KS site to which the device belongs.
+      attr_accessor :site_id
+      # Site name for the Salto KS site to which the device belongs.
+      attr_accessor :site_name
+    end
+
+    class DeviceSchlageMetadata < BaseResource
+      # Device ID for a Schlage device.
+      attr_accessor :device_id
+      # Device name for a Schlage device.
+      attr_accessor :device_name
+      # Model for a Schlage device.
+      attr_accessor :model
+    end
+
+    class DeviceSeamBridgeMetadata < BaseResource
+      # Device number for Seam Bridge.
+      attr_accessor :device_num
+      # Name for Seam Bridge.
+      attr_accessor :name
+      # Unlock method for Seam Bridge.
+      attr_accessor :unlock_method
+    end
+
+    class DeviceSensiMetadata < BaseResource
+      # Device ID for a Sensi device.
+      attr_accessor :device_id
+      # Device name for a Sensi device.
+      attr_accessor :device_name
+      # Set to true when the device does not support the /dual-setpoints API endpoint.
+      attr_accessor :dual_setpoints_not_supported
+      # Product type for a Sensi device.
+      attr_accessor :product_type
+    end
+
+    class DeviceSmartthingsMetadata < BaseResource
+      # Device ID for a SmartThings device.
+      attr_accessor :device_id
+      # Device name for a SmartThings device.
+      attr_accessor :device_name
+      # Location ID for a SmartThings device.
+      attr_accessor :location_id
+      # Model for a SmartThings device.
+      attr_accessor :model
+    end
+
+    class DeviceTadoMetadata < BaseResource
+      # Device type for a tado° device.
+      attr_accessor :device_type
+      # Serial number for a tado° device.
+      attr_accessor :serial_no
+    end
+
+    class DeviceTedeeMetadata < BaseResource
+      # Bridge ID for a Tedee device.
+      attr_accessor :bridge_id
+      # Bridge name for a Tedee device.
+      attr_accessor :bridge_name
+      # Device ID for a Tedee device.
+      attr_accessor :device_id
+      # Device model for a Tedee device.
+      attr_accessor :device_model
+      # Device name for a Tedee device.
+      attr_accessor :device_name
+      # Keypad ID for a Tedee device.
+      attr_accessor :keypad_id
+      # Serial number for a Tedee device.
+      attr_accessor :serial_number
+    end
+
+    class DeviceFeatures < BaseResource
+      # Indicates whether a TTLock device supports auto-lock time configuration.
+      attr_accessor :auto_lock_time_config
+      # Indicates whether a TTLock device supports an incomplete keyboard passcode.
+      attr_accessor :incomplete_keyboard_passcode
+      # Indicates whether a TTLock device supports the lock command.
+      attr_accessor :lock_command
+      # Indicates whether a TTLock device supports a passcode.
+      attr_accessor :passcode
+      # Indicates whether a TTLock device supports passcode management.
+      attr_accessor :passcode_management
+      # Indicates whether a TTLock device supports unlock via gateway.
+      attr_accessor :unlock_via_gateway
+      # Indicates whether a TTLock device supports Wi-Fi.
+      attr_accessor :wifi
+    end
+
+    class DeviceWirelessKeypads < BaseResource
+      # ID for a wireless keypad for a TTLock device.
+      attr_accessor :wireless_keypad_id
+      # Name for a wireless keypad for a TTLock device.
+      attr_accessor :wireless_keypad_name
+    end
+
+    class DeviceTtlockMetadata < BaseResource
+      # Feature value for a TTLock device.
+      attr_accessor :feature_value
+      # Indicates whether a TTLock device has a gateway.
+      attr_accessor :has_gateway
+      # Lock alias for a TTLock device.
+      attr_accessor :lock_alias
+      # Lock ID for a TTLock device.
+      attr_accessor :lock_id
+      # Lock-side timezone offset in milliseconds east of UTC, as configured in the TTLock app. Source of truth for the lock's wall-clock interpretation of access code start/end times — a misconfigured value here is the typical cause of customer "codes offset by N hours" reports. Diagnostic only; Seam does not convert times based on this value.
+      attr_accessor :timezone_raw_offset_ms
+      resource_accessor :features, DeviceFeatures
+      resource_list_accessor :wireless_keypads, DeviceWirelessKeypads
+    end
+
+    class DeviceTwoNMetadata < BaseResource
+      # Device ID for a 2N device.
+      attr_accessor :device_id
+      # Device name for a 2N device.
+      attr_accessor :device_name
+    end
+
+    class DeviceUltraloqMetadata < BaseResource
+      # Device ID for an Ultraloq device.
+      attr_accessor :device_id
+      # Device name for an Ultraloq device.
+      attr_accessor :device_name
+      # Device type for an Ultraloq device.
+      attr_accessor :device_type
+      # IANA timezone for the Ultraloq device.
+      attr_accessor :time_zone
+    end
+
+    class DeviceVisionlineMetadata < BaseResource
+      # Encoder ID for an ASSA ABLOY Visionline system.
+      attr_accessor :encoder_id
+    end
+
+    class DeviceWyzeMetadata < BaseResource
+      # Device ID for a Wyze device.
+      attr_accessor :device_id
+      # Device information model for a Wyze device.
+      attr_accessor :device_info_model
+      # Device name for a Wyze device.
+      attr_accessor :device_name
+      # Keypad UUID for a Wyze device.
+      attr_accessor :keypad_uuid
+      # Locker status (hardlock) for a Wyze device.
+      attr_accessor :locker_status_hardlock
+      # Product model for a Wyze device.
+      attr_accessor :product_model
+      # Product name for a Wyze device.
+      attr_accessor :product_name
+      # Product type for a Wyze device.
+      attr_accessor :product_type
+    end
+
+    class DeviceCodeConstraints < BaseResource
+      attr_accessor :constraint_type
+      # Maximum name length constraint for access codes.
+      attr_accessor :max_length
+      # Minimum name length constraint for access codes.
+      attr_accessor :min_length
+    end
+
+    class DeviceKeypadBattery < BaseResource
+      # Keypad battery charge level.
+      attr_accessor :level
+    end
+
+    class DeviceTimePairs < BaseResource
+      # Label for the start/end time pairing.
+      attr_accessor :display_name
+      # End time of day as a 24-hour `HH:MM` value, interpreted in the option's `time_zone`. An `end_time` earlier on the clock than `start_time` means the end falls on a later date.
+      attr_accessor :end_time
+      # Start time of day as a 24-hour `HH:MM` value, interpreted in the option's `time_zone`.
+      attr_accessor :start_time
+    end
+
+    class DeviceOfflineTimeFrameOptions < BaseResource
+      # Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+      attr_accessor :display_name
+      # iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+      attr_accessor :end_date_recurrence_rule
+      # When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+      attr_accessor :matching_start_end_time
+      # Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+      attr_accessor :max_duration
+      # Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+      attr_accessor :min_duration
+      # iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+      attr_accessor :start_date_recurrence_rule
+      # IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+      attr_accessor :time_zone
+      resource_list_accessor :time_pairs, DeviceTimePairs
+    end
+
+    class DeviceOnlineTimeFrameOptions < BaseResource
+      # Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+      attr_accessor :display_name
+      # iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+      attr_accessor :end_date_recurrence_rule
+      # When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+      attr_accessor :matching_start_end_time
+      # Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+      attr_accessor :max_duration
+      # Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+      attr_accessor :min_duration
+      # iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+      attr_accessor :start_date_recurrence_rule
+      # IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+      attr_accessor :time_zone
+      resource_list_accessor :time_pairs, DeviceTimePairs
+    end
+
+    class DeviceActiveThermostatSchedule < BaseResource
+      # Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+      attr_accessor :climate_preset_key
+      # ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.
+      attr_accessor :device_id
+      # Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+      attr_accessor :errors
+      # Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.
+      attr_accessor :is_override_allowed
+      # Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+      attr_accessor :max_override_period_minutes
+      # User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+      attr_accessor :name
+      # ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+      attr_accessor :thermostat_schedule_id
+      # ID of the workspace that contains the thermostat schedule.
+      attr_accessor :workspace_id
+      # Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.
+      date_accessor :created_at
+      # Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :ends_at
+      # Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      date_accessor :starts_at
+    end
+
+    class DeviceAvailableClimatePresets < BaseResource
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+      attr_accessor :can_delete
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+      attr_accessor :can_edit
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+      attr_accessor :can_use_with_thermostat_daily_programs
+      # Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :climate_preset_key
+      # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+      attr_accessor :climate_preset_mode
+      # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_celsius
+      # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_fahrenheit
+      # Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :display_name
+      # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+      attr_accessor :fan_mode_setting
+      # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_celsius
+      # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_fahrenheit
+      # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+      attr_accessor :hvac_mode_setting
+      # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+      attr_accessor :manual_override_allowed
+      # User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :name
+      resource_accessor :ecobee_metadata, DeviceEcobeeMetadata
+    end
+
+    class DeviceCurrentClimateSetting < BaseResource
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+      attr_accessor :can_delete
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+      attr_accessor :can_edit
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+      attr_accessor :can_use_with_thermostat_daily_programs
+      # Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :climate_preset_key
+      # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+      attr_accessor :climate_preset_mode
+      # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_celsius
+      # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_fahrenheit
+      # Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :display_name
+      # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+      attr_accessor :fan_mode_setting
+      # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_celsius
+      # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_fahrenheit
+      # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+      attr_accessor :hvac_mode_setting
+      # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+      attr_accessor :manual_override_allowed
+      # User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :name
+      resource_accessor :ecobee_metadata, DeviceEcobeeMetadata
+    end
+
+    class DeviceDefaultClimateSetting < BaseResource
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+      attr_accessor :can_delete
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+      attr_accessor :can_edit
+      # Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+      attr_accessor :can_use_with_thermostat_daily_programs
+      # Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :climate_preset_key
+      # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+      attr_accessor :climate_preset_mode
+      # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_celsius
+      # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :cooling_set_point_fahrenheit
+      # Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :display_name
+      # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+      attr_accessor :fan_mode_setting
+      # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_celsius
+      # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      attr_accessor :heating_set_point_fahrenheit
+      # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+      attr_accessor :hvac_mode_setting
+      # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+      attr_accessor :manual_override_allowed
+      # User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+      attr_accessor :name
+      resource_accessor :ecobee_metadata, DeviceEcobeeMetadata
+    end
+
+    class DeviceTemperatureThreshold < BaseResource
+      # Lower limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+      attr_accessor :lower_limit_celsius
+      # Lower limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+      attr_accessor :lower_limit_fahrenheit
+      # Upper limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+      attr_accessor :upper_limit_celsius
+      # Upper limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+      attr_accessor :upper_limit_fahrenheit
+    end
+
+    class DevicePeriods < BaseResource
+      # Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+      attr_accessor :climate_preset_key
+      # Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      attr_accessor :starts_at_time
+    end
+
+    class DeviceThermostatDailyPrograms < BaseResource
+      # ID of the thermostat device on which the thermostat daily program is configured.
+      attr_accessor :device_id
+      # User-friendly name to identify the thermostat daily program.
+      attr_accessor :name
+      # ID of the thermostat daily program.
+      attr_accessor :thermostat_daily_program_id
+      # ID of the workspace that contains the thermostat daily program.
+      attr_accessor :workspace_id
+      # Date and time at which the thermostat daily program was created.
+      date_accessor :created_at
+      resource_list_accessor :periods, DevicePeriods
+    end
+
+    class DeviceThermostatWeeklyProgram < BaseResource
+      # ID of the thermostat daily program to run on Fridays.
+      attr_accessor :friday_program_id
+      # ID of the thermostat daily program to run on Mondays.
+      attr_accessor :monday_program_id
+      # ID of the thermostat daily program to run on Saturdays.
+      attr_accessor :saturday_program_id
+      # ID of the thermostat daily program to run on Sundays.
+      attr_accessor :sunday_program_id
+      # ID of the thermostat daily program to run on Thursdays.
+      attr_accessor :thursday_program_id
+      # ID of the thermostat daily program to run on Tuesdays.
+      attr_accessor :tuesday_program_id
+      # ID of the thermostat daily program to run on Wednesdays.
+      attr_accessor :wednesday_program_id
+      # Date and time at which the thermostat weekly program was created.
+      date_accessor :created_at
+    end
+
+    class DeviceProperties < BaseResource
+      # Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+      attr_accessor :battery_level
+      # Array of noise threshold IDs that are currently triggering.
+      attr_accessor :currently_triggering_noise_threshold_ids
+      # Indicates whether the device has direct power.
+      attr_accessor :has_direct_power
+      # Alt text for the device image.
+      attr_accessor :image_alt_text
+      # Image URL for the device.
+      attr_accessor :image_url
+      # Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+      attr_accessor :manufacturer
+      # Name of the device.
+      attr_accessor :name
+      # Indicates current noise level in decibels, if the device supports noise detection.
+      attr_accessor :noise_level_decibels
+      # Indicates whether it is currently possible to use offline access codes for the device.
+      attr_accessor :offline_access_codes_enabled
+      # Indicates whether the device is online.
+      attr_accessor :online
+      # Indicates whether it is currently possible to use online access codes for the device.
+      attr_accessor :online_access_codes_enabled
+      # Serial number of the device.
+      attr_accessor :serial_number
+      attr_accessor :supports_accessory_keypad
+      attr_accessor :supports_offline_access_codes
+      # The delay in seconds before the lock automatically locks after being unlocked.
+      attr_accessor :auto_lock_delay_seconds
+      # Indicates whether automatic locking is enabled.
+      attr_accessor :auto_lock_enabled
+      # Indicates whether the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is currently enabled for the device. To disable it, set this to `false` using [/devices/update](https://docs.seam.co/api/devices/update).
+      attr_accessor :backup_access_code_pool_enabled
+      # Indicates whether the door is open.
+      attr_accessor :door_open
+      # Indicates whether the device supports native entry events.
+      attr_accessor :has_native_entry_events
+      # Indicates whether the lock is locked.
+      attr_accessor :locked
+      # Maximum number of active access codes that the device supports.
+      attr_accessor :max_active_codes_supported
+      # Supported code lengths for access codes.
+      attr_accessor :supported_code_lengths
+      # Indicates whether the device supports a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+      attr_accessor :supports_backup_access_code_pool
+      # ID of the active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+      attr_accessor :active_thermostat_schedule_id
+      # Climate preset modes that the thermostat supports, such as "home", "away", "wake", "sleep", "occupied", and "unoccupied".
+      attr_accessor :available_climate_preset_modes
+      # Fan mode settings that the thermostat supports.
+      attr_accessor :available_fan_mode_settings
+      # HVAC mode settings that the thermostat supports.
+      attr_accessor :available_hvac_mode_settings
+      # Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
+      attr_accessor :fallback_climate_preset_key
+      attr_accessor :fan_mode_setting
+      # Indicates whether the connected HVAC system is currently cooling, as reported by the thermostat.
+      attr_accessor :is_cooling
+      # Indicates whether the fan in the connected HVAC system is currently running, as reported by the thermostat.
+      attr_accessor :is_fan_running
+      # Indicates whether the connected HVAC system is currently heating, as reported by the thermostat.
+      attr_accessor :is_heating
+      # Indicates whether the current thermostat settings differ from the most recent active program or schedule that Seam activated. For this condition to occur, `current_climate_setting.manual_override_allowed` must also be `true`.
+      attr_accessor :is_temporary_manual_override_active
+      # Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+      attr_accessor :max_cooling_set_point_celsius
+      # Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+      attr_accessor :max_cooling_set_point_fahrenheit
+      # Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+      attr_accessor :max_heating_set_point_celsius
+      # Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+      attr_accessor :max_heating_set_point_fahrenheit
+      # Maximum number of periods that the thermostat can support per day. For example, if the thermostat supports 4 periods per day, this value is 4.
+      attr_accessor :max_thermostat_daily_program_periods_per_day
+      # Maximum number of climate presets that the thermostat can support for weekly programming.
+      attr_accessor :max_unique_climate_presets_per_thermostat_weekly_program
+      # Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+      attr_accessor :min_cooling_set_point_celsius
+      # Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+      attr_accessor :min_cooling_set_point_fahrenheit
+      # Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.
+      attr_accessor :min_heating_cooling_delta_celsius
+      # Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.
+      attr_accessor :min_heating_cooling_delta_fahrenheit
+      # Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+      attr_accessor :min_heating_set_point_celsius
+      # Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+      attr_accessor :min_heating_set_point_fahrenheit
+      # Reported relative humidity, as a value between 0 and 1, inclusive.
+      attr_accessor :relative_humidity
+      # Reported temperature in °C.
+      attr_accessor :temperature_celsius
+      # Reported temperature in °F.
+      attr_accessor :temperature_fahrenheit
+      # Precision of the thermostat's period in minutes. For example, if the thermostat supports 15-minute periods, this value is 15. All values are relative to the top of the hour, so for 15 minutes, the periods would be 0, 15, 30, and 45 minutes past the hour.
+      attr_accessor :thermostat_daily_program_period_precision_minutes
+      resource_accessor :accessory_keypad, DeviceAccessoryKeypad
+      resource_accessor :appearance, DeviceAppearance
+      resource_accessor :battery, DeviceBattery
+      resource_accessor :model, DeviceModel
+      resource_accessor :assa_abloy_credential_service_metadata, DeviceAssaAbloyCredentialServiceMetadata
+      resource_accessor :salto_space_credential_service_metadata, DeviceSaltoSpaceCredentialServiceMetadata
+      resource_accessor :akiles_metadata, DeviceAkilesMetadata
+      resource_accessor :aqara_metadata, DeviceAqaraMetadata
+      resource_accessor :assa_abloy_vostio_metadata, DeviceAssaAbloyVostioMetadata
+      resource_accessor :august_metadata, DeviceAugustMetadata
+      resource_accessor :avigilon_alta_metadata, DeviceAvigilonAltaMetadata
+      resource_accessor :brivo_metadata, DeviceBrivoMetadata
+      resource_accessor :controlbyweb_metadata, DeviceControlbywebMetadata
+      resource_accessor :dormakaba_oracode_metadata, DeviceDormakabaOracodeMetadata
+      resource_accessor :ecobee_metadata, DeviceEcobeeMetadata
+      resource_accessor :four_suites_metadata, DeviceFourSuitesMetadata
+      resource_accessor :genie_metadata, DeviceGenieMetadata
+      resource_accessor :honeywell_resideo_metadata, DeviceHoneywellResideoMetadata
+      resource_accessor :igloo_metadata, DeviceIglooMetadata
+      resource_accessor :igloohome_metadata, DeviceIgloohomeMetadata
+      resource_accessor :keynest_metadata, DeviceKeynestMetadata
+      resource_accessor :kisi_metadata, DeviceKisiMetadata
+      resource_accessor :korelock_metadata, DeviceKorelockMetadata
+      resource_accessor :kwikset_metadata, DeviceKwiksetMetadata
+      resource_accessor :lockly_metadata, DeviceLocklyMetadata
+      resource_accessor :minut_metadata, DeviceMinutMetadata
+      resource_accessor :nest_metadata, DeviceNestMetadata
+      resource_accessor :noiseaware_metadata, DeviceNoiseawareMetadata
+      resource_accessor :nuki_metadata, DeviceNukiMetadata
+      resource_accessor :omnitec_metadata, DeviceOmnitecMetadata
+      resource_accessor :ring_metadata, DeviceRingMetadata
+      resource_accessor :salto_ks_metadata, DeviceSaltoKsMetadata
+      resource_accessor :salto_metadata, DeviceSaltoMetadata
+      resource_accessor :schlage_metadata, DeviceSchlageMetadata
+      resource_accessor :seam_bridge_metadata, DeviceSeamBridgeMetadata
+      resource_accessor :sensi_metadata, DeviceSensiMetadata
+      resource_accessor :smartthings_metadata, DeviceSmartthingsMetadata
+      resource_accessor :tado_metadata, DeviceTadoMetadata
+      resource_accessor :tedee_metadata, DeviceTedeeMetadata
+      resource_accessor :ttlock_metadata, DeviceTtlockMetadata
+      resource_accessor :two_n_metadata, DeviceTwoNMetadata
+      resource_accessor :ultraloq_metadata, DeviceUltraloqMetadata
+      resource_accessor :visionline_metadata, DeviceVisionlineMetadata
+      resource_accessor :wyze_metadata, DeviceWyzeMetadata
+      resource_accessor :keypad_battery, DeviceKeypadBattery
+      resource_accessor :active_thermostat_schedule, DeviceActiveThermostatSchedule
+      resource_accessor :current_climate_setting, DeviceCurrentClimateSetting
+      resource_accessor :default_climate_setting, DeviceDefaultClimateSetting
+      resource_accessor :temperature_threshold, DeviceTemperatureThreshold
+      resource_accessor :thermostat_weekly_program, DeviceThermostatWeeklyProgram
+      resource_list_accessor :code_constraints, DeviceCodeConstraints
+      resource_list_accessor :offline_time_frame_options, DeviceOfflineTimeFrameOptions
+      resource_list_accessor :online_time_frame_options, DeviceOnlineTimeFrameOptions
+      resource_list_accessor :available_climate_presets, DeviceAvailableClimatePresets
+      resource_list_accessor :thermostat_daily_programs, DeviceThermostatDailyPrograms
+    end
+
     # Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
     class Device < BaseResource
+      resource_accessor :device_manufacturer, DeviceDeviceManufacturer
+      resource_accessor :device_provider, DeviceDeviceProvider
+      resource_accessor :location, DeviceLocation
+      resource_accessor :properties, DeviceProperties
       # Indicates whether the lock supports configuring automatic locking.
       attr_accessor :can_configure_auto_lock
       # Indicates whether the thermostat supports cooling.
@@ -52,22 +1085,14 @@ module Seam
       attr_accessor :custom_metadata
       # ID of the device.
       attr_accessor :device_id
-      # Manufacturer of the device. Represents the hardware brand, which may differ from the provider.
-      attr_accessor :device_manufacturer
-      # Provider of the device. Represents the third-party service through which the device is controlled.
-      attr_accessor :device_provider
       # Type of the device.
       attr_accessor :device_type
       # Display name of the device, defaults to nickname (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the device easily, especially when there are numerous devices.
       attr_accessor :display_name
       # Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
       attr_accessor :is_managed
-      # Location information for the device.
-      attr_accessor :location
       # Optional nickname to describe the device, settable through Seam.
       attr_accessor :nickname
-      # Properties of the device.
-      attr_accessor :properties
       # IDs of the spaces the device is in.
       attr_accessor :space_ids
       # Unique identifier for the Seam workspace associated with the device.

--- a/lib/seam/resources/event.rb
+++ b/lib/seam/resources/event.rb
@@ -2,15 +2,131 @@
 
 module Seam
   module Resources
+    class SeamEventAccessCodeErrors < BaseResource
+      # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      attr_accessor :error_code
+      # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Date and time at which Seam created the error.
+      date_accessor :created_at
+    end
+
+    class SeamEventAccessCodeWarnings < BaseResource
+      # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+      attr_accessor :warning_code
+      # Date and time at which Seam created the warning.
+      date_accessor :created_at
+    end
+
+    class SeamEventAcsSystemErrors < BaseResource
+      # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      attr_accessor :error_code
+      # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Date and time at which Seam created the error.
+      date_accessor :created_at
+    end
+
+    class SeamEventAcsSystemWarnings < BaseResource
+      # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+      attr_accessor :warning_code
+      # Date and time at which Seam created the warning.
+      date_accessor :created_at
+    end
+
+    class SeamEventChangedProperties < BaseResource
+      # Previous value of the property, or null if not set.
+      attr_accessor :from
+      # Name of the property that changed (e.g. `code`).
+      attr_accessor :property
+      # New value of the property, or null if cleared.
+      attr_accessor :to
+    end
+
+    class SeamEventConnectedAccountErrors < BaseResource
+      # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      attr_accessor :error_code
+      # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Date and time at which Seam created the error.
+      date_accessor :created_at
+    end
+
+    class SeamEventConnectedAccountWarnings < BaseResource
+      # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+      attr_accessor :warning_code
+      # Date and time at which Seam created the warning.
+      date_accessor :created_at
+    end
+
+    class SeamEventDeviceErrors < BaseResource
+      # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      attr_accessor :error_code
+      # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Date and time at which Seam created the error.
+      date_accessor :created_at
+    end
+
+    class SeamEventDeviceWarnings < BaseResource
+      # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      attr_accessor :message
+      # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+      attr_accessor :warning_code
+      # Date and time at which Seam created the warning.
+      date_accessor :created_at
+    end
+
+    class SeamEventFrom < BaseResource
+      # Previous name of the access code.
+      attr_accessor :name
+    end
+
+    class SeamEventReason < BaseResource
+      # Human-readable explanation of why access was denied.
+      attr_accessor :message
+      # Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+      attr_accessor :reason_code
+    end
+
+    class SeamEventRequestedMutations < BaseResource
+      # Previous property values before the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+      attr_accessor :from
+      # Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+      attr_accessor :mutation_code
+      # New property values after the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+      attr_accessor :to
+    end
+
+    class SeamEventTo < BaseResource
+      # New name of the access code.
+      attr_accessor :name
+    end
+
     class SeamEvent < BaseResource
-      # Errors associated with the access code.
-      attr_accessor :access_code_errors
+      resource_accessor :from, SeamEventFrom
+      resource_accessor :reason, SeamEventReason
+      resource_accessor :to, SeamEventTo
+      resource_list_accessor :access_code_errors, SeamEventAccessCodeErrors
+      resource_list_accessor :access_code_warnings, SeamEventAccessCodeWarnings
+      resource_list_accessor :acs_system_errors, SeamEventAcsSystemErrors
+      resource_list_accessor :acs_system_warnings, SeamEventAcsSystemWarnings
+      resource_list_accessor :changed_properties, SeamEventChangedProperties
+      resource_list_accessor :connected_account_errors, SeamEventConnectedAccountErrors
+      resource_list_accessor :connected_account_warnings, SeamEventConnectedAccountWarnings
+      resource_list_accessor :device_errors, SeamEventDeviceErrors
+      resource_list_accessor :device_warnings, SeamEventDeviceWarnings
+      resource_list_accessor :requested_mutations, SeamEventRequestedMutations
       # ID of the affected access code.
       attr_accessor :access_code_id
       # Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
       attr_accessor :access_code_is_managed
-      # Warnings associated with the access code.
-      attr_accessor :access_code_warnings
       # ID of the affected Access Grant.
       attr_accessor :access_grant_id
       # IDs of the access grants associated with this access method.
@@ -31,12 +147,8 @@ module Seam
       attr_accessor :acs_entrance_id
       # IDs of all ACS entrances currently attached to the space.
       attr_accessor :acs_entrance_ids
-      # Errors associated with the access control system.
-      attr_accessor :acs_system_errors
       # ID of the access system.
       attr_accessor :acs_system_id
-      # Warnings associated with the access control system.
-      attr_accessor :acs_system_warnings
       # ID of the affected access system user.
       attr_accessor :acs_user_id
       # ID of the affected action attempt.
@@ -53,8 +165,6 @@ module Seam
       attr_accessor :battery_status
       # Human-readable reason for the change (e.g. `ongoing code auto-renewed`).
       attr_accessor :change_reason
-      # List of properties that changed on the access code.
-      attr_accessor :changed_properties
       # ID of the affected client session.
       attr_accessor :client_session_id
       # Key of the climate preset that was activated.
@@ -65,14 +175,10 @@ module Seam
       attr_accessor :connect_webview_id
       # Custom metadata of the connected account, present when connected_account_id is provided.
       attr_accessor :connected_account_custom_metadata
-      # Errors associated with the connected account.
-      attr_accessor :connected_account_errors
       # ID of the connected account associated with the affected access code.
       attr_accessor :connected_account_id
       # undocumented: Unreleased.
       attr_accessor :connected_account_type
-      # Warnings associated with the connected account.
-      attr_accessor :connected_account_warnings
       # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
       attr_accessor :cooling_set_point_celsius
       # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
@@ -87,16 +193,12 @@ module Seam
       attr_accessor :desired_temperature_fahrenheit
       # Custom metadata of the device, present when device_id is provided.
       attr_accessor :device_custom_metadata
-      # Errors associated with the device.
-      attr_accessor :device_errors
       # ID of the device associated with the affected access code.
       attr_accessor :device_id
       # IDs of all devices currently attached to the space.
       attr_accessor :device_ids
       # Name of the deleted device, captured at deletion time. The device record no longer exists when this event fires, so the name is preserved here. Null when the device had no resolvable name.
       attr_accessor :device_name
-      # Warnings associated with the device.
-      attr_accessor :device_warnings
       # The new end time for the access grant.
       attr_accessor :ends_at
       # Error code associated with the disconnection event, if any.
@@ -110,8 +212,6 @@ module Seam
       attr_accessor :event_type
       # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
       attr_accessor :fan_mode_setting
-      # Previous access code name configuration.
-      attr_accessor :from
       # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
       attr_accessor :heating_set_point_celsius
       # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
@@ -150,10 +250,6 @@ module Seam
       attr_accessor :noise_threshold_name
       # Metadata from Noiseaware.
       attr_accessor :noiseaware_metadata
-      # Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
-      attr_accessor :reason
-      # Array of mutations requested on the access code, each containing the mutation type and from/to values.
-      attr_accessor :requested_mutations
       # ID of the affected space.
       attr_accessor :space_id
       # Unique key for the space within the workspace.
@@ -168,8 +264,6 @@ module Seam
       attr_accessor :temperature_fahrenheit
       # ID of the thermostat schedule that prompted the affected climate preset to be activated.
       attr_accessor :thermostat_schedule_id
-      # New access code name configuration.
-      attr_accessor :to
       # Upper temperature limit, in °C, defined by the set threshold.
       attr_accessor :upper_limit_celsius
       # Upper temperature limit, in °F, defined by the set threshold.

--- a/lib/seam/resources/instant_key.rb
+++ b/lib/seam/resources/instant_key.rb
@@ -2,14 +2,22 @@
 
 module Seam
   module Resources
+    class InstantKeyCustomization < BaseResource
+      # URL of the logo displayed on the Instant Key.
+      attr_accessor :logo_url
+      # Primary color used in the Instant Key UI.
+      attr_accessor :primary_color
+      # Secondary color used in the Instant Key UI.
+      attr_accessor :secondary_color
+    end
+
     # Represents a Seam Instant Key. For issuing Bluetooth mobile keys, Instant Keys are the fastest way to share access. With a single API call, you can create a mobile key and send it through text or email or embed it in your own app.
     #
     # There’s no app to install, nor account to create. Your user just taps a link and gets a lightweight, native-feeling experience using iOS App Clip or Instant Apps on Android. Further, Instant Keys work offline, so even in areas with poor cellular or Wi-Fi, like elevator banks or concrete-walled hallways, the Instant Keys still work.
     class InstantKey < BaseResource
+      resource_accessor :customization, InstantKeyCustomization
       # ID of the client session associated with the Instant Key.
       attr_accessor :client_session_id
-      # Customization applied to the Instant Key UI.
-      attr_accessor :customization
       # ID of the customization profile associated with the Instant Key.
       attr_accessor :customization_profile_id
       # ID of the Instant Key.

--- a/lib/seam/resources/phone.rb
+++ b/lib/seam/resources/phone.rb
@@ -2,8 +2,32 @@
 
 module Seam
   module Resources
+    class PhoneEndpoints < BaseResource
+      # ID of the associated endpoint.
+      attr_accessor :endpoint_id
+      # Indicated whether the endpoint is active.
+      attr_accessor :is_active
+    end
+
+    class PhoneAssaAbloyCredentialServiceMetadata < BaseResource
+      # Indicates whether the credential service has active endpoints associated with the phone.
+      attr_accessor :has_active_endpoint
+      resource_list_accessor :endpoints, PhoneEndpoints
+    end
+
+    class PhoneSaltoSpaceCredentialServiceMetadata < BaseResource
+      # Indicates whether the credential service has an active associated phone.
+      attr_accessor :has_active_phone
+    end
+
+    class PhoneProperties < BaseResource
+      resource_accessor :assa_abloy_credential_service_metadata, PhoneAssaAbloyCredentialServiceMetadata
+      resource_accessor :salto_space_credential_service_metadata, PhoneSaltoSpaceCredentialServiceMetadata
+    end
+
     # Represents an app user's mobile phone.
     class Phone < BaseResource
+      resource_accessor :properties, PhoneProperties
       # Optional [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.
       attr_accessor :custom_metadata
       # ID of the phone.
@@ -14,8 +38,6 @@ module Seam
       attr_accessor :display_name
       # Optional nickname to describe the phone, settable through Seam.
       attr_accessor :nickname
-      # Properties of the phone.
-      attr_accessor :properties
       # ID of the workspace that contains the phone.
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/resource_errors_support.rb
+++ b/lib/seam/resources/resource_errors_support.rb
@@ -3,6 +3,11 @@
 module Seam
   module Resources
     module ResourceErrorsSupport
+      def update_from_response(data)
+        @errors_converted = nil
+        super
+      end
+
       def errors
         @errors_converted ||= @errors.is_a?(Array) ? Seam::Resources::ResourceError.load_from_response(@errors) : []
       end

--- a/lib/seam/resources/resource_warnings_support.rb
+++ b/lib/seam/resources/resource_warnings_support.rb
@@ -3,6 +3,11 @@
 module Seam
   module Resources
     module ResourceWarningsSupport
+      def update_from_response(data)
+        @warnings_converted = nil
+        super
+      end
+
       def warnings
         @warnings_converted ||= @warnings.is_a?(Array) ? Seam::Resources::ResourceWarning.load_from_response(@warnings) : []
       end

--- a/lib/seam/resources/space.rb
+++ b/lib/seam/resources/space.rb
@@ -2,20 +2,36 @@
 
 module Seam
   module Resources
+    class SpaceCustomerData < BaseResource
+      # Postal address for the space.
+      attr_accessor :address
+      # Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+      attr_accessor :default_checkin_time
+      # Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+      attr_accessor :default_checkout_time
+      # IANA time zone for the space, e.g. America/Los_Angeles.
+      attr_accessor :time_zone
+    end
+
+    class SpaceGeolocation < BaseResource
+      # Latitude of the space, in decimal degrees.
+      attr_accessor :latitude
+      # Longitude of the space, in decimal degrees.
+      attr_accessor :longitude
+    end
+
     # Represents a space that is a logical grouping of devices and entrances. You can assign access to an entire space, thereby making granting access more efficient.
     class Space < BaseResource
+      resource_accessor :customer_data, SpaceCustomerData
+      resource_accessor :geolocation, SpaceGeolocation
       # Number of entrances in the space.
       attr_accessor :acs_entrance_count
-      # Reservation/stay-related defaults for the space. Also carries the provider/PMS-supplied name under a `<connector_type>_name` key (e.g. `guesty_name`), which Seam preserves when you rename the space (read-only — managed by Seam).
-      attr_accessor :customer_data
       # Customer key associated with the space.
       attr_accessor :customer_key
       # Number of devices in the space.
       attr_accessor :device_count
       # Display name for the space.
       attr_accessor :display_name
-      # Geographic coordinates (latitude and longitude) of the space.
-      attr_accessor :geolocation
       # Name of the space.
       attr_accessor :name
       # ID of the space.

--- a/lib/seam/resources/thermostat_daily_program.rb
+++ b/lib/seam/resources/thermostat_daily_program.rb
@@ -2,14 +2,20 @@
 
 module Seam
   module Resources
+    class ThermostatDailyProgramPeriods < BaseResource
+      # Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+      attr_accessor :climate_preset_key
+      # Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+      attr_accessor :starts_at_time
+    end
+
     # Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.
     class ThermostatDailyProgram < BaseResource
+      resource_list_accessor :periods, ThermostatDailyProgramPeriods
       # ID of the thermostat device on which the thermostat daily program is configured.
       attr_accessor :device_id
       # User-friendly name to identify the thermostat daily program.
       attr_accessor :name
-      # Array of thermostat daily program periods.
-      attr_accessor :periods
       # ID of the thermostat daily program.
       attr_accessor :thermostat_daily_program_id
       # ID of the workspace that contains the thermostat daily program.

--- a/lib/seam/resources/unmanaged_access_code.rb
+++ b/lib/seam/resources/unmanaged_access_code.rb
@@ -2,6 +2,25 @@
 
 module Seam
   module Resources
+    class UnmanagedAccessCodeDormakabaOracodeMetadata < BaseResource
+      # Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+      attr_accessor :is_cancellable
+      # Indicates whether early check-in is available for this stay.
+      attr_accessor :is_early_checkin_able
+      # Indicates whether the stay can be extended via the Dormakaba Oracode API.
+      attr_accessor :is_extendable
+      # Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+      attr_accessor :is_overridable
+      # Dormakaba Oracode site name associated with this access code.
+      attr_accessor :site_name
+      # Dormakaba Oracode stay ID associated with this access code.
+      attr_accessor :stay_id
+      # Dormakaba Oracode user level ID associated with this access code.
+      attr_accessor :user_level_id
+      # Dormakaba Oracode user level name associated with this access code.
+      attr_accessor :user_level_name
+    end
+
     # Represents an [unmanaged smart lock access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
     #
     # An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
@@ -14,6 +33,7 @@ module Seam
     #
     # - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
     class UnmanagedAccessCode < BaseResource
+      resource_accessor :dormakaba_oracode_metadata, UnmanagedAccessCodeDormakabaOracodeMetadata
       # Unique identifier for the access code.
       attr_accessor :access_code_id
       # Indicates that Seam cannot convert this unmanaged access code to a managed access code. Some providers do not support management of unmanaged access codes through API integrations.
@@ -24,8 +44,6 @@ module Seam
       attr_accessor :code
       # Unique identifier for the device associated with the access code.
       attr_accessor :device_id
-      # Metadata for a dormakaba Oracode unmanaged access code. Only present for unmanaged access codes from dormakaba Oracode devices.
-      attr_accessor :dormakaba_oracode_metadata
       # Indicates that Seam does not manage the access code.
       attr_accessor :is_managed
       # Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).

--- a/lib/seam/resources/unmanaged_access_grant.rb
+++ b/lib/seam/resources/unmanaged_access_grant.rb
@@ -2,8 +2,50 @@
 
 module Seam
   module Resources
+    class UnmanagedAccessGrantFrom < BaseResource
+      # Previous device IDs where access codes existed.
+      attr_accessor :device_ids
+    end
+
+    class UnmanagedAccessGrantTo < BaseResource
+      # Common code key to ensure PIN code reuse across devices.
+      attr_accessor :common_code_key
+      # New device IDs where access codes should be created.
+      attr_accessor :device_ids
+    end
+
+    class UnmanagedAccessGrantPendingMutations < BaseResource
+      # IDs of the access methods being updated.
+      attr_accessor :access_method_ids
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of updating the spaces (devices) associated with this access grant.
+      attr_accessor :mutation_code
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      resource_accessor :from, UnmanagedAccessGrantFrom
+      resource_accessor :to, UnmanagedAccessGrantTo
+    end
+
+    class UnmanagedAccessGrantRequestedAccessMethods < BaseResource
+      # Specific PIN code to use for this access method. Only applicable when mode is 'code'.
+      attr_accessor :code
+      # IDs of the access methods created for the requested access method.
+      attr_accessor :created_access_method_ids
+      # Display name of the access method.
+      attr_accessor :display_name
+      # Maximum number of times the instant key can be used. Only applicable when mode is 'mobile_key'. Defaults to 1 if not specified.
+      attr_accessor :instant_key_max_use_count
+      # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+      attr_accessor :mode
+      # Date and time at which the requested access method was added to the Access Grant.
+      date_accessor :created_at
+    end
+
     # Represents an unmanaged Access Grant. Unmanaged Access Grants do not have client sessions, instant keys, customization profiles, or keys.
     class UnmanagedAccessGrant < BaseResource
+      resource_list_accessor :pending_mutations, UnmanagedAccessGrantPendingMutations
+      resource_list_accessor :requested_access_methods, UnmanagedAccessGrantRequestedAccessMethods
       # ID of the Access Grant.
       attr_accessor :access_grant_id
       # IDs of the access methods created for the Access Grant.
@@ -14,10 +56,6 @@ module Seam
       attr_accessor :location_ids
       # Name of the Access Grant. If not provided, the display name will be computed.
       attr_accessor :name
-      # List of pending mutations for the access grant. This shows updates that are in progress.
-      attr_accessor :pending_mutations
-      # Access methods that the user requested for the Access Grant.
-      attr_accessor :requested_access_methods
       # Reservation key for the access grant.
       attr_accessor :reservation_key
       # IDs of the spaces to which the Access Grant gives access.

--- a/lib/seam/resources/unmanaged_access_method.rb
+++ b/lib/seam/resources/unmanaged_access_method.rb
@@ -2,8 +2,30 @@
 
 module Seam
   module Resources
+    class UnmanagedAccessMethodFrom < BaseResource
+      # Previous device IDs where access was provisioned.
+      attr_accessor :device_ids
+    end
+
+    class UnmanagedAccessMethodTo < BaseResource
+      # New device IDs where access is being provisioned.
+      attr_accessor :device_ids
+    end
+
+    class UnmanagedAccessMethodPendingMutations < BaseResource
+      # Detailed description of the mutation.
+      attr_accessor :message
+      # Mutation code to indicate that Seam is in the process of provisioning access for this access method on new devices.
+      attr_accessor :mutation_code
+      # Date and time at which the mutation was created.
+      date_accessor :created_at
+      resource_accessor :from, UnmanagedAccessMethodFrom
+      resource_accessor :to, UnmanagedAccessMethodTo
+    end
+
     # Represents an unmanaged access method. Unmanaged access methods do not have client sessions, instant keys, customization profiles, or keys.
     class UnmanagedAccessMethod < BaseResource
+      resource_list_accessor :pending_mutations, UnmanagedAccessMethodPendingMutations
       # ID of the access method.
       attr_accessor :access_method_id
       # The actual PIN code for code access methods.
@@ -22,8 +44,6 @@ module Seam
       attr_accessor :is_ready_for_encoding
       # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       attr_accessor :mode
-      # Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
-      attr_accessor :pending_mutations
       # ID of the Seam workspace associated with the access method.
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/unmanaged_device.rb
+++ b/lib/seam/resources/unmanaged_device.rb
@@ -2,8 +2,65 @@
 
 module Seam
   module Resources
+    class UnmanagedDeviceLocation < BaseResource
+      # Name of the device location.
+      attr_accessor :location_name
+      # Time zone of the device location.
+      attr_accessor :time_zone
+      # Time zone of the device location.
+      attr_accessor :timezone
+    end
+
+    class UnmanagedDeviceBattery < BaseResource
+      attr_accessor :level
+    end
+
+    class UnmanagedDeviceAccessoryKeypad < BaseResource
+      # Indicates if an accessory keypad is connected to the device.
+      attr_accessor :is_connected
+      resource_accessor :battery, UnmanagedDeviceBattery
+    end
+
+    class UnmanagedDeviceModel < BaseResource
+      attr_accessor :accessory_keypad_supported
+      # Indicates whether the device can connect a accessory keypad.
+      attr_accessor :can_connect_accessory_keypad
+      # Display name of the device model.
+      attr_accessor :display_name
+      # Indicates whether the device has a built in accessory keypad.
+      attr_accessor :has_built_in_keypad
+      # Display name that corresponds to the manufacturer-specific terminology for the device.
+      attr_accessor :manufacturer_display_name
+      attr_accessor :offline_access_codes_supported
+      attr_accessor :online_access_codes_supported
+    end
+
+    class UnmanagedDeviceProperties < BaseResource
+      # Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+      attr_accessor :battery_level
+      # Alt text for the device image.
+      attr_accessor :image_alt_text
+      # Image URL for the device.
+      attr_accessor :image_url
+      # Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+      attr_accessor :manufacturer
+      # Name of the device.
+      attr_accessor :name
+      # Indicates whether it is currently possible to use offline access codes for the device.
+      attr_accessor :offline_access_codes_enabled
+      # Indicates whether the device is online.
+      attr_accessor :online
+      # Indicates whether it is currently possible to use online access codes for the device.
+      attr_accessor :online_access_codes_enabled
+      resource_accessor :accessory_keypad, UnmanagedDeviceAccessoryKeypad
+      resource_accessor :battery, UnmanagedDeviceBattery
+      resource_accessor :model, UnmanagedDeviceModel
+    end
+
     # Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
     class UnmanagedDevice < BaseResource
+      resource_accessor :location, UnmanagedDeviceLocation
+      resource_accessor :properties, UnmanagedDeviceProperties
       # Indicates whether the lock supports configuring automatic locking.
       attr_accessor :can_configure_auto_lock
       # Indicates whether the thermostat supports cooling.
@@ -56,10 +113,6 @@ module Seam
       attr_accessor :device_type
       # Indicates that Seam does not manage the device.
       attr_accessor :is_managed
-      # Location information for the device.
-      attr_accessor :location
-      # properties of the device.
-      attr_accessor :properties
       # Unique identifier for the Seam workspace associated with the device.
       attr_accessor :workspace_id
 

--- a/lib/seam/resources/workspace.rb
+++ b/lib/seam/resources/workspace.rb
@@ -2,13 +2,26 @@
 
 module Seam
   module Resources
+    class WorkspaceConnectWebviewCustomization < BaseResource
+      # URL of the inviter logo for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+      attr_accessor :inviter_logo_url
+      # Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+      attr_accessor :logo_shape
+      # Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+      attr_accessor :primary_button_color
+      # Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+      attr_accessor :primary_button_text_color
+      # Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+      attr_accessor :success_message
+    end
+
     # Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
     class Workspace < BaseResource
+      resource_accessor :connect_webview_customization, WorkspaceConnectWebviewCustomization
       # Company name associated with the [workspace](https://docs.seam.co/core-concepts/workspaces).
       attr_accessor :company_name
       # @deprecated Use `company_name` instead.
       attr_accessor :connect_partner_name
-      attr_accessor :connect_webview_customization
       # Indicates whether publishable key authentication is enabled for this workspace.
       attr_accessor :is_publishable_key_auth_enabled
       # Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).

--- a/spec/deep_hash_accessor_spec.rb
+++ b/spec/deep_hash_accessor_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe Seam::DeepHashAccessor do
       expect(accessor.address.street).to eq("123 Main St")
       expect(accessor.address.city).to eq("San Francisco")
     end
+
+    it "reuses processed nested values" do
+      expect(accessor.address).to equal(accessor.address)
+    end
+  end
+
+  describe "subscript access" do
+    it "accepts string and symbol keys" do
+      expect(accessor["name"]).to eq(accessor.name)
+      expect(accessor[:name]).to eq(accessor.name)
+    end
+
+    it "returns nil for an unknown key" do
+      expect(accessor[:non_existent_key]).to be_nil
+    end
   end
 
   describe "array handling" do

--- a/spec/resources/base_resource_hash_spec.rb
+++ b/spec/resources/base_resource_hash_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Seam::Resources::BaseResource do
   describe "hash handling" do
     let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
-    it "does not wrap empty hashes in DeepHashAccessor" do
+    it "does not wrap undeclared empty hashes in DeepHashAccessor" do
       data = {
         device_id: "123",
         empty_hash: {},
@@ -18,6 +18,26 @@ RSpec.describe Seam::Resources::BaseResource do
       expect(resource.instance_variable_get(:@empty_hash)).not_to be_a(Seam::DeepHashAccessor)
 
       expect(resource.instance_variable_get(:@non_empty_hash)).to be_a(Seam::DeepHashAccessor)
+    end
+
+    it "uses generated resources for declared nested objects" do
+      device = Seam::Resources::Device.new(
+        properties: {locked: true},
+        custom_metadata: {customer_id: "customer-1"}
+      )
+
+      expect(device.properties).to be_a(Seam::Resources::DeviceProperties)
+      expect(device.properties.locked).to be(true)
+      expect(device.properties[:locked]).to be(true)
+      expect { device.properties.unknown }.to raise_error(NoMethodError)
+      expect(device.custom_metadata).to be_a(Seam::DeepHashAccessor)
+      expect(device.custom_metadata.customer_id).to eq("customer-1")
+    end
+
+    it "uses a generated resource for an empty declared object" do
+      device = Seam::Resources::Device.new(properties: {})
+
+      expect(device.properties).to be_a(Seam::Resources::DeviceProperties)
     end
   end
 end

--- a/spec/resources/base_resource_spec.rb
+++ b/spec/resources/base_resource_spec.rb
@@ -15,4 +15,30 @@ RSpec.describe Seam::Resources::BaseResource do
       expect(device.created_at).to be_a(Time)
     end
   end
+
+  describe ".load_from_response" do
+    it "returns nil for a nil response" do
+      expect(described_class.load_from_response(nil)).to be_nil
+    end
+  end
+
+  describe "response attributes" do
+    it "skips invalid attribute names without aborting construction" do
+      resource = described_class.new("has-dash" => true, "valid" => "kept")
+
+      expect(resource.instance_variable_get(:@valid)).to eq("kept")
+      expect(resource.data["has-dash"]).to be(true)
+    end
+  end
+
+  describe "#update_from_response" do
+    it "refreshes converted errors" do
+      device = Seam::Resources::Device.new(errors: [{error_code: "first"}])
+      expect(device.errors.first.error_code).to eq("first")
+
+      device.update_from_response(errors: [{error_code: "second"}])
+
+      expect(device.errors.first.error_code).to eq("second")
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

- Fix a live bug where `DeepHashAccessor#[]` always returned `nil` and produced non-stable nested objects, and prevent response deserialization from aborting on invalid Ruby ivar names.
- Ensure memoized/converted `errors`/`warnings` are refreshed after `update_from_response` to avoid stale data.
- Provide static, documented nested resource types so nested properties have YARD docs and IDE autocompletion by generating `BaseResource` subclasses for nested objects and lists.
- Leave the top-level decision about stripping unknown response keys (P3) unchanged for a later, separate decision.

### Description

- Corrected `DeepHashAccessor`: `#[]` now delegates to the generated singleton readers (accepting string or symbol keys) and `create_accessor_methods` now processes values once at construction to preserve identity. (`lib/seam/deep_hash_accessor.rb`).
- Hardened `BaseResource` deserialization to return `nil` from `load_from_response(nil)`, skip response keys that cannot be valid instance variable names, added `BaseResource#[]` for bracket access, and introduced `resource_accessor` / `resource_list_accessor` DSL and conversion logic to instantiate typed nested resources when present. (`lib/seam/base_resource.rb`).
- Fixed stale memoization by resetting `@errors_converted` and `@warnings_converted` before delegating `update_from_response` in the resource support modules, and updated the emitted string literals used by the generator (`codegen/lib/static-resources.ts` → `lib/seam/resources/resource_errors_support.rb` and `resource_warnings_support.rb`).
- Implemented nested-class discovery in the Ruby code generator: added `merge-properties` helper and updated `codegen/lib/layouts/resource.ts` and `codegen/layouts/resource.hbs` so generated `lib/seam/resources/*.rb` now emit documented nested `BaseResource` subclasses and declare `resource_accessor` / `resource_list_accessor` usages; numerous generated resource files were refreshed accordingly.
- Added and updated specs to cover the fixes and generation: `spec/deep_hash_accessor_spec.rb`, `spec/resources/base_resource_hash_spec.rb`, and `spec/resources/base_resource_spec.rb` now assert bracket access, stable nested identity, nil handling for `load_from_response(nil)`, skipping invalid attribute names, `errors` refresh on update, and that declared nested objects become generated typed resources.

### Testing

- Ran the unit specs with `bundle exec rspec` for the modified suites and they passed (including `spec/deep_hash_accessor_spec.rb`, `spec/resources/base_resource_spec.rb`, and `spec/resources/base_resource_hash_spec.rb`).
- Ran the full test/lint/generation pipeline: `npm run generate` (generator run and idempotency check), `rake lint`, and `rake test` completed successfully after minor tooling fixes in the generator templates.
- Performed TypeScript checks with `npm run typecheck` and JavaScript lint/format (`npm run lint` / `prettier`) during generator development and fixed reported issues; note that the local Node runtime triggered an engine warning because it is older than the project dev engine requirement (this did not prevent generation in this environment).
- Verified that code generation is idempotent and that generated resource files now include nested typed classes and `resource_accessor` declarations as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a74119bedb88329b5a162b50455bc98)