### PR TITLE
refactor: drop the open_timeout comment

### DIFF
--- a/lib/seam/request.rb
+++ b/lib/seam/request.rb
@@ -17,7 +17,6 @@ module Seam
         default_options = {
           url: endpoint,
           headers: auth_headers.merge(default_headers),
-          # open_timeout bounds the connect phase, which timeout does not cover.
           request: {timeout: timeout, open_timeout: timeout}
         }
 


### PR DESCRIPTION
Follow-up to #540, which is already merged and released in 2.134.0, so this is a new branch off `main` rather than more commits on the old one.

Removes the explanatory comment above the `request:` defaults in `create_faraday_client`. The code is unchanged.

92 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1)_