### PR TITLE
Support Blueprint boolean constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Please refer to the official [Seam Docs](https://docs.seam.co/latest/) to get st
 Parts of this SDK are generated from always up-to-date type information
 provided by [@seamapi/types](https://github.com/seamapi/types/).
 This ensures all API methods, request shapes, and response shapes are
-accurate and fully typed.
+accurate and fully typed. Ruby cannot statically enforce literal booleans, so
+the generated YARD types use `TrueClass` and `FalseClass` to document singleton
+constraints.
 
 <!-- toc -->
 

--- a/codegen/lib/handlebars-helpers.ts
+++ b/codegen/lib/handlebars-helpers.ts
@@ -34,10 +34,20 @@ const nullable = (
   value: { isOptional: boolean; isNullable: boolean },
 ): string => (value.isOptional || value.isNullable ? `${type}, nil` : type)
 
-const scalarType = (format: string, isInt = false): string => {
+const scalarType = (
+  format: string,
+  isInt = false,
+  booleanValues?: boolean[],
+): string => {
   switch (format) {
-    case 'boolean':
-      return 'Boolean'
+    case 'boolean': {
+      const values = [...new Set(booleanValues)]
+      return values.length === 1
+        ? values[0]
+          ? 'TrueClass'
+          : 'FalseClass'
+        : 'Boolean'
+    }
     case 'number':
       return isInt ? 'Integer' : 'Float'
     case 'datetime':
@@ -61,6 +71,7 @@ export const rubyPropertyType = (property: Property): string => {
       : scalarType(
           property.format,
           property.format === 'number' && property.isInt,
+          property.format === 'boolean' ? property.values : undefined,
         )
   // BaseResource normalizes response lists to [] even when the API sends nil.
   return nullable(
@@ -93,6 +104,7 @@ export const rubyParameterType = (parameter: Parameter): string => {
       : scalarType(
           parameter.format,
           parameter.format === 'number' && parameter.isInt,
+          parameter.format === 'boolean' ? parameter.values : undefined,
         )
   // Only a nullable parameter accepts the Seam::NULL sentinel, and only an
   // optional parameter accepts nil.

--- a/codegen/lib/merge-properties.ts
+++ b/codegen/lib/merge-properties.ts
@@ -64,6 +64,19 @@ const mergeOccurrences = (occurrences: Property[], path: string): Property => {
     )
   }
 
+  if (first.format === 'boolean') {
+    const booleans = occurrences as Array<
+      Extract<Property, { format: 'boolean' }>
+    >
+    const values = booleans.some(({ values }) => values == null)
+      ? undefined
+      : [...new Set(booleans.flatMap(({ values }) => values ?? []))]
+    const merged = { ...first, ...docs }
+    if (values == null) delete merged.values
+    else merged.values = values
+    return merged
+  }
+
   if (first.format === 'object') {
     return {
       ...first,

--- a/lib/seam/resources/access_code.rb
+++ b/lib/seam/resources/access_code.rb
@@ -62,7 +62,7 @@ module Seam
         # @return [String]
         attr_accessor :error_code
         # Indicates that this is an access code error.
-        # @return [Boolean]
+        # @return [TrueClass]
         attr_accessor :is_access_code_error
         # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
         # @return [Boolean, nil]
@@ -197,7 +197,7 @@ module Seam
       # @return [Boolean]
       attr_accessor :is_external_modification_allowed
       # Indicates whether Seam manages the access code.
-      # @return [Boolean]
+      # @return [TrueClass]
       attr_accessor :is_managed
       # Indicates whether the access code is intended for use in offline scenarios. If `true`, this code can be created on a device without a network connection.
       # @return [Boolean]

--- a/lib/seam/resources/acs_access_group.rb
+++ b/lib/seam/resources/acs_access_group.rb
@@ -135,7 +135,7 @@ module Seam
       # @return [String]
       attr_accessor :external_type_display_name
       # Indicates whether Seam manages the access group.
-      # @return [Boolean]
+      # @return [TrueClass]
       attr_accessor :is_managed
       # Name of the access group.
       # @return [String]

--- a/lib/seam/resources/acs_credential.rb
+++ b/lib/seam/resources/acs_credential.rb
@@ -150,7 +150,7 @@ module Seam
       # @return [Boolean, nil]
       attr_accessor :is_latest_desired_state_synced_with_provider
       # Indicates whether Seam manages the credential.
-      # @return [Boolean]
+      # @return [TrueClass]
       attr_accessor :is_managed
       # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
       # @return [Boolean, nil]

--- a/lib/seam/resources/acs_user.rb
+++ b/lib/seam/resources/acs_user.rb
@@ -179,7 +179,7 @@ module Seam
       # @return [String, nil]
       attr_accessor :hid_acs_system_id
       # Indicates whether Seam manages the access system user.
-      # @return [Boolean]
+      # @return [TrueClass]
       attr_accessor :is_managed
       # Indicates whether the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is currently [suspended](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users).
       # @return [Boolean, nil]

--- a/lib/seam/resources/device.rb
+++ b/lib/seam/resources/device.rb
@@ -1004,7 +1004,7 @@ module Seam
           # @return [String, nil]
           attr_accessor :end_date_recurrence_rule
           # When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
-          # @return [Boolean, nil]
+          # @return [TrueClass, nil]
           attr_accessor :matching_start_end_time
           # Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
           # @return [String, nil]
@@ -1043,7 +1043,7 @@ module Seam
           # @return [String, nil]
           attr_accessor :end_date_recurrence_rule
           # When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
-          # @return [Boolean, nil]
+          # @return [TrueClass, nil]
           attr_accessor :matching_start_end_time
           # Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
           # @return [String, nil]
@@ -1796,7 +1796,7 @@ module Seam
       # @return [String]
       attr_accessor :display_name
       # Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
-      # @return [Boolean]
+      # @return [TrueClass]
       attr_accessor :is_managed
       # Optional nickname to describe the device, settable through Seam.
       # @return [String, nil]

--- a/lib/seam/resources/unmanaged_access_code.rb
+++ b/lib/seam/resources/unmanaged_access_code.rb
@@ -64,7 +64,7 @@ module Seam
         # @return [String]
         attr_accessor :error_code
         # Indicates that this is an access code error.
-        # @return [Boolean]
+        # @return [TrueClass]
         attr_accessor :is_access_code_error
         # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
         # @return [Boolean, nil]
@@ -130,10 +130,10 @@ module Seam
       # @return [String]
       attr_accessor :access_code_id
       # Indicates that Seam cannot convert this unmanaged access code to a managed access code. Some providers do not support management of unmanaged access codes through API integrations.
-      # @return [Boolean, nil]
+      # @return [TrueClass, nil]
       attr_accessor :cannot_be_managed
       # Indicates that Seam cannot delete this unmanaged access code through the provider. If this access code needs to be deleted, it will only be possible from the manufacturer app.
-      # @return [Boolean, nil]
+      # @return [TrueClass, nil]
       attr_accessor :cannot_delete_unmanaged_access_code
       # Code used for access. Typically, a numeric or alphanumeric string.
       # @return [String, nil]
@@ -142,7 +142,7 @@ module Seam
       # @return [String]
       attr_accessor :device_id
       # Indicates that Seam does not manage the access code.
-      # @return [Boolean]
+      # @return [FalseClass]
       attr_accessor :is_managed
       # Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
       # @return [String, nil]

--- a/lib/seam/resources/unmanaged_device.rb
+++ b/lib/seam/resources/unmanaged_device.rb
@@ -231,7 +231,7 @@ module Seam
       # @return [String]
       attr_accessor :device_type
       # Indicates that Seam does not manage the device.
-      # @return [Boolean]
+      # @return [FalseClass]
       attr_accessor :is_managed
       # Unique identifier for the Seam workspace associated with the device.
       # @return [String]

--- a/lib/seam/routes/access_grants_unmanaged.rb
+++ b/lib/seam/routes/access_grants_unmanaged.rb
@@ -37,7 +37,7 @@ module Seam
       #
       # When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
       # @param access_grant_id [String] ID of the unmanaged Access Grant to update.
-      # @param is_managed [Boolean] Must be set to true to convert the unmanaged access grant to managed.
+      # @param is_managed [TrueClass] Must be set to true to convert the unmanaged access grant to managed.
       # @param access_grant_key [String, nil] Unique key for the access grant. If not provided, the existing key will be preserved.
       # @return [nil] OK
       def update(access_grant_id:, is_managed:, access_grant_key: nil)

--- a/lib/seam/routes/devices_unmanaged.rb
+++ b/lib/seam/routes/devices_unmanaged.rb
@@ -53,7 +53,7 @@ module Seam
       # An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
       # @param device_id [String] ID of the unmanaged device that you want to update.
       # @param custom_metadata [Hash, nil] Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs.
-      # @param is_managed [Boolean, nil] Indicates whether the device is managed. Set this parameter to `true` to convert an unmanaged device to managed.
+      # @param is_managed [TrueClass, nil] Indicates whether the device is managed. Set this parameter to `true` to convert an unmanaged device to managed.
       # @return [nil] OK
       def update(device_id:, custom_metadata: nil, is_managed: nil)
         @client.patch("/devices/unmanaged/update", {device_id: device_id, custom_metadata: custom_metadata, is_managed: is_managed}.compact)

--- a/lib/seam/routes/user_identities_unmanaged.rb
+++ b/lib/seam/routes/user_identities_unmanaged.rb
@@ -32,7 +32,7 @@ module Seam
       # Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
       #
       # This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
-      # @param is_managed [Boolean] Must be set to true to convert the unmanaged user identity to managed.
+      # @param is_managed [TrueClass] Must be set to true to convert the unmanaged user identity to managed.
       # @param user_identity_id [String] ID of the unmanaged user identity that you want to update.
       # @param user_identity_key [String, nil] Unique key for the user identity. If not provided, the existing key will be preserved.
       # @return [nil] OK

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@seamapi/ruby",
       "devDependencies": {
-        "@seamapi/blueprint": "^1.5.1",
+        "@seamapi/blueprint": "^1.6.0",
         "@seamapi/fake-seam-connect": "2.0.4",
         "@seamapi/smith": "^1.1.0",
         "@seamapi/types": "1.1001.0",
@@ -788,9 +788,9 @@
       "license": "MIT"
     },
     "node_modules/@seamapi/blueprint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.5.1.tgz",
-      "integrity": "sha512-rXHMNDGmaE7OK+tg3e64DnpMHQypN4BuSS+PkVqGUoYc9f+xBMONqPscsHAGi9iU/iyZOJZKEOKOXvMmWaLoLA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.6.0.tgz",
+      "integrity": "sha512-+lIriSgog0E0pUjXz/tdRZiVECiSiBcnZ3uU4JRN45RTLs2BQVbR+Ris6/mXwBV1wkpMetdVD3CP1BB1agf6Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@seamapi/blueprint": "^1.5.1",
+    "@seamapi/blueprint": "^1.6.0",
     "@seamapi/fake-seam-connect": "2.0.4",
     "@seamapi/smith": "^1.1.0",
     "@seamapi/types": "1.1001.0",


### PR DESCRIPTION
## Summary
- update `@seamapi/blueprint` to 1.6.0
- generate `TrueClass` and `FalseClass` YARD types for singleton boolean constraints
- preserve unconstrained and multi-value booleans as `Boolean`
- merge boolean constraints across flattened variants and regenerate the SDK
- document Ruby’s lack of statically enforced literal booleans

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run generate`