### PR TITLE
feat: Restore discriminated variants in the Ruby SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,9 @@ workspaces = seam.workspaces.list
 
 ### Webhooks
 
-The Seam API implements webhooks using [Svix](https://www.svix.com).This SDK exports a thin wrapper `Seam::Webhook` around the svix package.
+The Seam API implements webhooks using [Svix](https://www.svix.com). This SDK exports a thin wrapper `Seam::Webhook` around the svix package.
 Use it to parse and validate Seam webhook events.
+Known event types load as `Seam::Resources::SeamEvent` subclasses with only that event's accessors; unknown types remain generic `SeamEvent` instances for forward compatibility.
 
 > [!TIP]
 > This example is for [Sinatra](https://sinatrarb.com/), see the [Svix docs for more examples in specific frameworks](https://docs.svix.com/receiving/verifying-payloads/how).
@@ -402,22 +403,25 @@ post "/webhook" do
       "svix-signature" => request.env["HTTP_SVIX_SIGNATURE"],
       "svix-timestamp" => request.env["HTTP_SVIX_TIMESTAMP"]
     }
-    data = webhook.verify(request.body.read, headers)
+    event = webhook.verify(request.body.read, headers)
   rescue Seam::WebhookVerificationError
     halt 400, "Bad Request"
   end
 
   begin
-    store_event(data)
+    case event.event_type
+    when "access_code.created"
+      puts "Access code created: #{event.access_code_id}"
+    when "device.connected"
+      puts "Device connected: #{event.device_id}"
+    else
+      puts event
+    end
   rescue
     halt 500, "Internal Server Error"
   end
 
   204
-end
-
-def store_event(data)
-  puts data
 end
 ```
 

--- a/codegen/layouts/partials/resource-class.hbs
+++ b/codegen/layouts/partials/resource-class.hbs
@@ -1,40 +1,58 @@
-{{indent}}class {{className}} < BaseResource
+{{#if description}}
+{{{rubyDoc description indentation}}}
+{{/if}}
+{{indent}}class {{className}} < {{superclass}}
 {{#each nestedClasses}}
+{{> resource-class}}
+{{/each}}
+{{#each variants}}
 {{> resource-class}}
 {{/each}}
 {{#each resourceAccessors}}
 {{#if description}}
 {{{rubyDoc description ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}# @return [{{rubyResourceType this}}]
+{{../bodyIndent}}# @return [{{rubyResourceType this}}]{{{rubyEnumValuesDoc this ../docIndent}}}
 {{../bodyIndent}}resource_accessor :{{name}}, {{className}}
 {{/each}}
 {{#each resourceListAccessors}}
 {{#if description}}
 {{{rubyDoc description ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}# @return [{{rubyResourceType this}}]
+{{../bodyIndent}}# @return [{{rubyResourceType this}}]{{{rubyEnumValuesDoc this ../docIndent}}}
 {{../bodyIndent}}resource_list_accessor :{{name}}, {{className}}
 {{/each}}
 {{#each accessors}}
 {{#if description}}
 {{{rubyDoc description ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}# @return [{{rubyPropertyType this}}]
+{{../bodyIndent}}# @return [{{rubyPropertyType this}}]{{{rubyEnumValuesDoc this ../docIndent}}}
 {{#if isDeprecated}}
 {{{rubyDeprecatedDoc this ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}attr_accessor :{{name}}
+{{#if isAliased}}
+{{../bodyIndent}}aliased_accessor :{{accessorName}}, from: :{{name}}
+{{else}}
+{{../bodyIndent}}attr_accessor :{{accessorName}}
+{{/if}}
 {{/each}}
 {{#each dateAccessors}}
 {{#if description}}
 {{{rubyDoc description ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}# @return [{{rubyPropertyType this}}]
+{{../bodyIndent}}# @return [{{rubyPropertyType this}}]{{{rubyEnumValuesDoc this ../docIndent}}}
 {{#if isDeprecated}}
 {{{rubyDeprecatedDoc this ../docIndent}}}
 {{/if}}
-{{../bodyIndent}}date_accessor :{{name}}
+{{../bodyIndent}}date_accessor :{{accessorName}}
 {{/each}}
+{{#if discriminator}}
+
+{{bodyIndent}}discriminated_by :{{discriminator}}, {
+{{#each variants}}
+{{../bodyIndent}}  {{{rubyString discriminatorValue}}} => {{className}},
+{{/each}}
+{{bodyIndent}}{{identity "}"}}.freeze
+{{/if}}
 {{indent}}end
 

--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -12,41 +12,56 @@ module Seam
 {{#each nestedClasses}}
 {{> resource-class}}
 {{/each}}
+{{#each variants}}
+{{> resource-class}}
+{{/each}}
 {{#each resourceAccessors}}
 {{#if description}}
 {{{rubyDoc description 6}}}
 {{/if}}
-      # @return [{{rubyResourceType this}}]
+      # @return [{{rubyResourceType this}}]{{{rubyEnumValuesDoc this 6}}}
       resource_accessor :{{name}}, {{className}}
 {{/each}}
 {{#each resourceListAccessors}}
 {{#if description}}
 {{{rubyDoc description 6}}}
 {{/if}}
-      # @return [{{rubyResourceType this}}]
+      # @return [{{rubyResourceType this}}]{{{rubyEnumValuesDoc this 6}}}
       resource_list_accessor :{{name}}, {{className}}
 {{/each}}
 {{#each accessors}}
 {{#if description}}
 {{{rubyDoc description 6}}}
 {{/if}}
-      # @return [{{rubyPropertyType this}}]
+      # @return [{{rubyPropertyType this}}]{{{rubyEnumValuesDoc this 6}}}
 {{#if isDeprecated}}
 {{{rubyDeprecatedDoc this 6}}}
 {{/if}}
-      attr_accessor :{{name}}
+{{#if isAliased}}
+      aliased_accessor :{{accessorName}}, from: :{{name}}
+{{else}}
+      attr_accessor :{{accessorName}}
+{{/if}}
 {{/each}}
 {{#each dateAccessors}}
 
 {{#if description}}
 {{{rubyDoc description 6}}}
 {{/if}}
-      # @return [{{rubyPropertyType this}}]
+      # @return [{{rubyPropertyType this}}]{{{rubyEnumValuesDoc this 6}}}
 {{#if isDeprecated}}
 {{{rubyDeprecatedDoc this 6}}}
 {{/if}}
-      date_accessor :{{name}}
+      date_accessor :{{accessorName}}
 {{/each}}
+{{#if discriminator}}
+
+      discriminated_by :{{discriminator}}, {
+{{#each variants}}
+        {{{rubyString discriminatorValue}}} => {{className}},
+{{/each}}
+      }.freeze
+{{/if}}
     end
   end
 end

--- a/codegen/lib/handlebars-helpers.ts
+++ b/codegen/lib/handlebars-helpers.ts
@@ -29,6 +29,26 @@ export const rubyDeprecatedDoc = (
       )
     : ''
 
+export const rubyString = (value: string): string => JSON.stringify(value)
+
+export const rubyEnumValuesDoc = (
+  property: Property,
+  indentation: number,
+): string => {
+  const values =
+    property.format === 'enum'
+      ? property.values
+      : property.format === 'list' && property.itemFormat === 'enum'
+        ? property.itemEnumValues
+        : []
+  return values.length === 0
+    ? ''
+    : `\n${comment(
+        ['Known values:', ...values.map(({ name }) => `- \`${name}\``)],
+        indentation,
+      )}`
+}
+
 const nullable = (
   type: string,
   value: { isOptional: boolean; isNullable: boolean },

--- a/codegen/lib/layouts/resource.ts
+++ b/codegen/lib/layouts/resource.ts
@@ -1,40 +1,67 @@
 // Builds the template context for resource files
 // (lib/seam/resources/{snake_name}.rb).
 
-import type { Property } from '@seamapi/blueprint'
+import type { DiscriminatedListProperty, Property } from '@seamapi/blueprint'
 import { pascalCase } from 'change-case'
 
 import { convertCustomResourceName } from '../custom-resource-name-conversions.js'
 import { mergeProperties } from '../merge-properties.js'
 
 type ResourceAccessor = Property & Documented & { className: string }
+type PropertyAccessor = Property &
+  Documented & {
+    accessorName: string
+    isAliased: boolean
+  }
+
+export interface DiscriminatedVariantSource {
+  discriminatorValue: string
+  description: string
+  properties: Property[]
+}
+
+interface ResourceVariant extends ResourceClass {
+  discriminatorValue: string
+}
 
 export interface ResourceClass {
   className: string
+  superclass: string
+  description: string
+  indentation: number
   indent: string
   bodyIndent: string
   docIndent: number
-  accessors: Array<Property & Documented>
-  dateAccessors: Array<Property & Documented>
+  accessors: PropertyAccessor[]
+  dateAccessors: PropertyAccessor[]
   resourceAccessors: ResourceAccessor[]
   resourceListAccessors: ResourceAccessor[]
   nestedClasses: ResourceClass[]
+  discriminator: string | null
+  variants: ResourceVariant[]
 }
 
 export interface ResourceLayoutContext {
   className: string
   resource: Documented
-  accessors: Array<Property & Documented>
-  dateAccessors: Array<Property & Documented>
+  accessors: PropertyAccessor[]
+  dateAccessors: PropertyAccessor[]
   nestedClasses: ResourceClass[]
   resourceAccessors: ResourceAccessor[]
   resourceListAccessors: ResourceAccessor[]
+  discriminator: string | null
+  variants: ResourceVariant[]
 }
 
 interface Documented {
   description: string
   isDeprecated: boolean
   deprecationMessage: string
+}
+
+interface DiscriminatedSource {
+  discriminator: string
+  variants: DiscriminatedVariantSource[]
 }
 
 // Resource classes open inside `module Seam; module Resources`.
@@ -48,6 +75,97 @@ const maxNestingDepth = 16
 // from the enclosing lexical scope.
 const reservedClassNames = new Set(['BaseResource', 'Resources', 'Seam'])
 
+const isErrorOrWarningList = (
+  property: Property,
+): property is DiscriminatedListProperty =>
+  property.format === 'list' &&
+  property.itemFormat === 'discriminated_object' &&
+  ['error_code', 'warning_code'].includes(property.discriminator)
+
+const sameDescription = (properties: Property[]): string => {
+  const descriptions = new Set(properties.map(({ description }) => description))
+  return descriptions.size === 1 ? (properties[0]?.description ?? '') : ''
+}
+
+// A fallback class only promises scalar fields every known variant carries.
+// Variant-only and nested fields stay on their specific subclasses.
+export const getCommonScalarProperties = (
+  propertyLists: Property[][],
+): Property[] => {
+  const [first = []] = propertyLists
+  const result: Property[] = []
+
+  for (const property of first) {
+    if (
+      property.format === 'list' ||
+      property.format === 'object' ||
+      property.format === 'record'
+    ) {
+      continue
+    }
+
+    const occurrences = propertyLists.map((properties) =>
+      properties.find(({ name }) => name === property.name),
+    )
+    if (
+      occurrences.some(
+        (occurrence) =>
+          occurrence == null || occurrence.format !== property.format,
+      )
+    ) {
+      continue
+    }
+
+    const present = occurrences as Property[]
+    const docs = {
+      description: sameDescription(present),
+      isOptional: present.some(({ isOptional }) => isOptional),
+      isNullable: present.some(({ isNullable }) => isNullable),
+    }
+
+    if (property.format === 'enum') {
+      const values = new Map(
+        present.flatMap((occurrence) =>
+          occurrence.format === 'enum'
+            ? occurrence.values.map((value) => [value.name, value] as const)
+            : [],
+        ),
+      )
+      result.push({ ...property, ...docs, values: [...values.values()] })
+    } else if (property.format === 'boolean') {
+      const booleans = present.filter(
+        (occurrence): occurrence is Extract<Property, { format: 'boolean' }> =>
+          occurrence.format === 'boolean',
+      )
+      const common = { ...property, ...docs }
+      if (booleans.some(({ values }) => values == null)) {
+        delete common.values
+      } else {
+        common.values = [
+          ...new Set(booleans.flatMap(({ values }) => values ?? [])),
+        ]
+      }
+      result.push(common)
+    } else {
+      result.push({ ...property, ...docs })
+    }
+  }
+
+  return result
+}
+
+const getDiscriminatorValue = (
+  properties: Property[],
+  discriminator: string,
+): string => {
+  const property = properties.find(({ name }) => name === discriminator)
+  const value = property?.format === 'enum' ? property.values[0]?.name : null
+  if (value == null) {
+    throw new Error(`Missing enum discriminator ${discriminator}.`)
+  }
+  return value
+}
+
 const getNestedProperties = (property: Property): Property[] | undefined => {
   if (property.format === 'object') return property.properties
   if (property.format === 'list' && property.itemFormat === 'object') {
@@ -57,6 +175,11 @@ const getNestedProperties = (property: Property): Property[] | undefined => {
     property.format === 'list' &&
     property.itemFormat === 'discriminated_object'
   ) {
+    if (['error_code', 'warning_code'].includes(property.discriminator)) {
+      return getCommonScalarProperties(
+        property.variants.map(({ properties }) => properties),
+      )
+    }
     return mergeProperties(
       property.variants.map((variant) => variant.properties),
     )
@@ -64,11 +187,49 @@ const getNestedProperties = (property: Property): Property[] | undefined => {
   return undefined
 }
 
+const getVariantClassName = (value: string): string =>
+  pascalCase(value).replaceAll(/_(?=\d)/g, 'N')
+
+const addVariants = (
+  resourceClass: ResourceClass,
+  source: DiscriminatedSource,
+  path: string,
+): void => {
+  const takenClassNames = new Set(
+    resourceClass.nestedClasses.map(({ className }) => className),
+  )
+
+  resourceClass.discriminator = source.discriminator
+  resourceClass.variants = source.variants.map((variant) => {
+    const className = getVariantClassName(variant.discriminatorValue)
+    if (reservedClassNames.has(className) || takenClassNames.has(className)) {
+      throw new Error(
+        `The variants at ${path} generate the duplicate or reserved class name ${className}.`,
+      )
+    }
+    takenClassNames.add(className)
+
+    return {
+      ...buildClass(
+        className,
+        variant.properties,
+        `${path}.${variant.discriminatorValue}`,
+        resourceClass.indentation + 2,
+        resourceClass.className,
+        variant.description,
+      ),
+      discriminatorValue: variant.discriminatorValue,
+    }
+  })
+}
+
 const buildClass = (
   className: string,
   classProperties: Property[],
   path: string,
   indentation: number,
+  superclass = 'BaseResource',
+  description = '',
 ): ResourceClass => {
   if (indentation > rootIndentation + 2 * maxNestingDepth) {
     throw new Error(
@@ -106,46 +267,79 @@ const buildClass = (
     const destination =
       property.format === 'list' ? resourceListAccessors : resourceAccessors
     destination.push({ ...property, className: nestedClassName })
-    nestedClasses.push(
-      buildClass(
-        nestedClassName,
-        nestedProperties,
-        nestedPath,
-        indentation + 2,
-      ),
+
+    const discriminated = isErrorOrWarningList(property)
+    const nestedClass = buildClass(
+      nestedClassName,
+      nestedProperties,
+      nestedPath,
+      indentation + 2,
+      'BaseResource',
+      discriminated
+        ? `Known \`${property.discriminator}\` values load as subclasses; unknown values remain ${nestedClassName} instances for forward compatibility.`
+        : '',
     )
+    if (discriminated) {
+      addVariants(
+        nestedClass,
+        {
+          discriminator: property.discriminator,
+          variants: property.variants.map((variant) => ({
+            discriminatorValue: getDiscriminatorValue(
+              variant.properties,
+              property.discriminator,
+            ),
+            description: variant.description,
+            properties: variant.properties,
+          })),
+        },
+        nestedPath,
+      )
+    }
+    nestedClasses.push(nestedClass)
   }
 
   const typedNames = new Set(
     [...resourceAccessors, ...resourceListAccessors].map(({ name }) => name),
   )
+  const toPropertyAccessor = (property: Property): PropertyAccessor => {
+    const isAliased = property.name === 'method' && path.startsWith('event.')
+    return {
+      ...property,
+      accessorName: isAliased ? 'event_method' : property.name,
+      isAliased,
+    }
+  }
 
   return {
     className,
+    superclass,
+    description,
+    indentation,
     indent: ' '.repeat(indentation),
     bodyIndent: ' '.repeat(indentation + 2),
     docIndent: indentation + 2,
-    accessors: classProperties.filter(
-      (property) =>
-        property.format !== 'datetime' && !typedNames.has(property.name),
-    ),
-    dateAccessors: classProperties.filter(
-      (property) => property.format === 'datetime',
-    ),
+    accessors: classProperties
+      .filter(
+        (property) =>
+          property.format !== 'datetime' && !typedNames.has(property.name),
+      )
+      .map(toPropertyAccessor),
+    dateAccessors: classProperties
+      .filter((property) => property.format === 'datetime')
+      .map(toPropertyAccessor),
     resourceAccessors,
     resourceListAccessors,
     nestedClasses,
+    discriminator: null,
+    variants: [],
   }
 }
 
 export const setResourceLayoutContext = (
   snakeName: string,
   properties: Property[],
-  resource: {
-    description: string
-    isDeprecated: boolean
-    deprecationMessage: string
-  },
+  resource: Documented & Partial<DiscriminatedSource>,
 ): ResourceLayoutContext => {
   const className = pascalCase(convertCustomResourceName(snakeName))
   const rootClass = buildClass(
@@ -154,6 +348,13 @@ export const setResourceLayoutContext = (
     snakeName,
     rootIndentation,
   )
+  if (resource.discriminator != null && resource.variants != null) {
+    addVariants(
+      rootClass,
+      { discriminator: resource.discriminator, variants: resource.variants },
+      snakeName,
+    )
+  }
 
   return {
     className,
@@ -163,5 +364,7 @@ export const setResourceLayoutContext = (
     nestedClasses: rootClass.nestedClasses,
     resourceAccessors: rootClass.resourceAccessors,
     resourceListAccessors: rootClass.resourceListAccessors,
+    discriminator: rootClass.discriminator,
+    variants: rootClass.variants,
   }
 }

--- a/codegen/lib/routes.ts
+++ b/codegen/lib/routes.ts
@@ -2,8 +2,8 @@
 // Structured to mirror the javascript-http codegen plugin (lib/connect.ts).
 //
 // The blueprint from @seamapi/blueprint drives all generated output: resources
-// come from blueprint.resources (plus the merged action_attempt and the
-// pagination resources), and clients come from blueprint.routes and
+// come from blueprint.resources (plus discriminated action attempts and the
+// pagination resource), and clients come from blueprint.routes and
 // blueprint.namespaces.
 
 import type {
@@ -20,9 +20,12 @@ import { convertCustomResourceName } from './custom-resource-name-conversions.js
 import { rubyParameterType } from './handlebars-helpers.js'
 import { setClientLayoutContext } from './layouts/client.js'
 import { setImportsLayoutContext } from './layouts/imports.js'
-import { setResourceLayoutContext } from './layouts/resource.js'
+import {
+  type DiscriminatedVariantSource,
+  getCommonScalarProperties,
+  setResourceLayoutContext,
+} from './layouts/resource.js'
 import { setRoutesFileLayoutContext } from './layouts/routes-file.js'
-import { mergeProperties } from './merge-properties.js'
 import type { ClientMethod, ClientModel } from './ruby-client.js'
 
 interface Metadata {
@@ -87,6 +90,46 @@ type ResourceDocumentation = Pick<
 
 interface ResourceSource extends ResourceDocumentation {
   properties: Property[]
+  discriminator?: string
+  variants?: DiscriminatedVariantSource[]
+}
+
+const createActionAttemptBaseProperties = (
+  variants: DiscriminatedVariantSource[],
+): Property[] => {
+  const propertyLists = variants.map(({ properties }) => properties)
+  const common = getCommonScalarProperties(propertyLists)
+  const nested = ['error', 'result'].flatMap((name) => {
+    const occurrences = propertyLists.map((properties) =>
+      properties.find((property) => property.name === name),
+    )
+    if (
+      occurrences.some(
+        (property) => property == null || property.format !== 'object',
+      )
+    ) {
+      return []
+    }
+
+    const objects = occurrences as Array<
+      Extract<Property, { format: 'object' }>
+    >
+    const first = objects[0]
+    if (first == null) return []
+    return [
+      {
+        ...first,
+        description:
+          name === 'error' ? 'Error associated with the action.' : '',
+        isNullable: true,
+        properties: getCommonScalarProperties(
+          objects.map(({ properties }) => properties),
+        ),
+      },
+    ]
+  })
+
+  return [...common, ...nested].sort((a, b) => a.name.localeCompare(b.name))
 }
 
 const getResources = (
@@ -98,32 +141,41 @@ const getResources = (
     resources.set(resource.resourceType, resource)
   }
 
-  // The event resource only has the properties common to all events, but the
-  // SDK exposes a single SeamEvent class, so it needs an accessor for every
-  // property of every event variant.
   const eventResource = resources.get('event')
   if (eventResource != null) {
     resources.set('event', {
       ...eventResource,
-      properties: mergeProperties([
-        eventResource.properties,
-        ...blueprint.events.map((event) => event.properties),
-      ]),
+      description:
+        'Represents a Seam event. Known event types load as subclasses; unknown event types remain SeamEvent instances for forward compatibility.',
+      discriminator: 'event_type',
+      variants: blueprint.events.map((event) => ({
+        discriminatorValue: event.eventType,
+        description: event.description,
+        properties: event.properties,
+      })),
     })
   }
 
-  // Action attempts are one blueprint entry per action type, but the SDK
-  // exposes a single ActionAttempt class.
   if (blueprint.actionAttempts.length > 0) {
-    const resource = blueprint.actionAttempts[0]
-    if (resource == null) throw new Error('Expected an action attempt resource')
-    resources.set('action_attempt', {
-      ...resource,
-      properties: mergeProperties(
-        blueprint.actionAttempts.map(
-          (actionAttempt) => actionAttempt.properties,
-        ),
+    const variants = blueprint.actionAttempts.map((actionAttempt) => ({
+      discriminatorValue: actionAttempt.actionAttemptType,
+      description: actionAttempt.description,
+      // Action attempts can return null for both fields while pending. The
+      // blueprint currently loses that per-status nullability upstream.
+      properties: actionAttempt.properties.map((property) =>
+        ['error', 'result'].includes(property.name)
+          ? { ...property, isNullable: true }
+          : property,
       ),
+    }))
+    resources.set('action_attempt', {
+      description:
+        'Represents a Seam action attempt. Known action types load as subclasses; unknown action types remain ActionAttempt instances for forward compatibility.',
+      isDeprecated: false,
+      deprecationMessage: '',
+      properties: createActionAttemptBaseProperties(variants),
+      discriminator: 'action_type',
+      variants,
     })
   }
 

--- a/lib/seam/base_resource.rb
+++ b/lib/seam/base_resource.rb
@@ -23,10 +23,21 @@ module Seam
         return nil if data.nil?
 
         if data.is_a?(Array)
-          data.map { |d| new(d, client) }
+          data.map { |item| load_from_response(item, client) }
         else
-          new(data, client)
+          resource_class = if data.is_a?(Hash) && @discriminator
+            value = data[@discriminator] || data[@discriminator.to_sym]
+            @discriminated_variants.fetch(value, self)
+          else
+            self
+          end
+          resource_class.new(data, client)
         end
+      end
+
+      def self.discriminated_by(attribute, variants)
+        @discriminator = attribute.to_s
+        @discriminated_variants = variants
       end
 
       def inspect
@@ -50,6 +61,11 @@ module Seam
         attr_accessor attr
       end
 
+      def self.aliased_accessor(attr, from:)
+        attribute_aliases[from.to_s] = attr
+        attr_accessor attr
+      end
+
       def self.resource_list_accessor(attr, resource_class)
         resource_list_accessors[attr.to_s] = resource_class
         attr_writer attr
@@ -68,6 +84,10 @@ module Seam
 
       def self.resource_list_accessors
         @resource_list_accessors ||= {}
+      end
+
+      def self.attribute_aliases
+        @attribute_aliases ||= {}
       end
 
       def self.date_accessor(*attrs)
@@ -99,7 +119,8 @@ module Seam
           else
             process_hash_value(value)
           end
-          instance_variable_set(:"@#{key}", value)
+          attribute = self.class.attribute_aliases.fetch(key.to_s, key)
+          instance_variable_set(:"@#{attribute}", value)
         end
       end
 

--- a/lib/seam/resources/access_code.rb
+++ b/lib/seam/resources/access_code.rb
@@ -39,50 +39,483 @@ module Seam
         attr_accessor :user_level_name
       end
 
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
-        class ModifiedFields < BaseResource
-          # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+        # Indicates a provider-specific issue that prevents the access code from being set or managed. Check the error message for details.
+        class ProviderIssue < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
           # @return [String]
-          attr_accessor :field
-          # The previous value of the field.
-          # @return [String, nil]
-          attr_accessor :from
-          # The new value of the field.
-          # @return [String, nil]
-          attr_accessor :to
+          # Known values:
+          # - `provider_issue`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
         end
 
-        # List of fields that were changed externally, with their previous and new values.
-        # @return [Array<ModifiedFields>]
-        resource_list_accessor :modified_fields, ModifiedFields
-        # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
-        # @return [String, nil]
-        attr_accessor :change_type
+        # Failed to set code on device.
+        class FailedToSetOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_set_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Failed to remove code from device.
+        class FailedToRemoveFromDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_remove_from_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Duplicate access code detected on device.
+        class DuplicateCodeOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `duplicate_code_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+          # @return [String, nil]
+          attr_accessor :managed_access_code_id
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+          # @return [String, nil]
+          attr_accessor :unmanaged_access_code_id
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # No space for access code on device.
+        class NoSpaceForAccessCodeOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `no_space_for_access_code_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Code was modified or removed externally after Seam successfully set it on the device. The external change conflicts with the state that Seam is trying to apply, so Seam will attempt to set the code on the device again.
+        class ConflictingExternalModification < Errors
+          class ModifiedFields < BaseResource
+            # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            # @return [String]
+            attr_accessor :field
+            # The previous value of the field.
+            # @return [String, nil]
+            attr_accessor :from
+            # The new value of the field.
+            # @return [String, nil]
+            attr_accessor :to
+          end
+
+          # List of fields that were changed externally, with their previous and new values.
+          # @return [Array<ModifiedFields>]
+          resource_list_accessor :modified_fields, ModifiedFields
+          # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+          # @return [String, nil]
+          # Known values:
+          # - `modified`
+          # - `removed`
+          attr_accessor :change_type
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `conflicting_external_modification`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access code is disabled or inactive on the device. The code exists but will not grant access until re-enabled.
+        class AccessCodeInactive < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `access_code_inactive`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Indicates that the account is disconnected.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto site user limit has been reached.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam's integration user does not have sufficient permissions on the provider's system to which this device belongs, so Seam cannot manage access codes or unlock the device. See the error message for specifics, then either reauthorize the connected account in Seam or grant the integration user the required permissions in the provider's system.
+        class InsufficientPermissions < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `insufficient_permissions`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account could not be connected. Contact dormakaba support.
+        class DormakabaSitesDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is offline.
+        class DeviceOffline < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_offline`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has been removed.
+        class DeviceRemoved < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_removed`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the hub is disconnected.
+        class HubDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is disconnected.
+        class DeviceDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is empty.
+        class EmptyBackupAccessCodePool < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `empty_backup_access_code_pool`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the user is not authorized to use the August lock.
+        class AugustLockNotAuthorized < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `august_lock_not_authorized`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that device credentials are missing.
+        class MissingDeviceCredentials < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `missing_device_credentials`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the auxiliary heat is running.
+        class AuxiliaryHeatRunning < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `auxiliary_heat_running`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a subscription is required to connect.
+        class SubscriptionRequired < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `subscription_required`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `provider_issue`
+        # - `failed_to_set_on_device`
+        # - `failed_to_remove_from_device`
+        # - `duplicate_code_on_device`
+        # - `no_space_for_access_code_on_device`
+        # - `conflicting_external_modification`
+        # - `access_code_inactive`
+        # - `account_disconnected`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `insufficient_permissions`
+        # - `dormakaba_sites_disconnected`
+        # - `device_offline`
+        # - `device_removed`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        # - `empty_backup_access_code_pool`
+        # - `august_lock_not_authorized`
+        # - `missing_device_credentials`
+        # - `auxiliary_heat_running`
+        # - `subscription_required`
+        # - `bridge_disconnected`
         attr_accessor :error_code
-        # Indicates that this is an access code error.
-        # @return [TrueClass]
-        attr_accessor :is_access_code_error
-        # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
-        # @return [Boolean, nil]
-        attr_accessor :is_bridge_error
-        # @return [Boolean, nil]
-        attr_accessor :is_connected_account_error
-        # @return [Boolean]
-        attr_accessor :is_device_error
-        # ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
-        # @return [String, nil]
-        attr_accessor :managed_access_code_id
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
-        # @return [String, nil]
-        attr_accessor :unmanaged_access_code_id
         # Date and time at which Seam created the error.
         # @return [Time, nil]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "provider_issue" => ProviderIssue,
+          "failed_to_set_on_device" => FailedToSetOnDevice,
+          "failed_to_remove_from_device" => FailedToRemoveFromDevice,
+          "duplicate_code_on_device" => DuplicateCodeOnDevice,
+          "no_space_for_access_code_on_device" => NoSpaceForAccessCodeOnDevice,
+          "conflicting_external_modification" => ConflictingExternalModification,
+          "access_code_inactive" => AccessCodeInactive,
+          "account_disconnected" => AccountDisconnected,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "insufficient_permissions" => InsufficientPermissions,
+          "dormakaba_sites_disconnected" => DormakabaSitesDisconnected,
+          "device_offline" => DeviceOffline,
+          "device_removed" => DeviceRemoved,
+          "hub_disconnected" => HubDisconnected,
+          "device_disconnected" => DeviceDisconnected,
+          "empty_backup_access_code_pool" => EmptyBackupAccessCodePool,
+          "august_lock_not_authorized" => AugustLockNotAuthorized,
+          "missing_device_credentials" => MissingDeviceCredentials,
+          "auxiliary_heat_running" => AuxiliaryHeatRunning,
+          "subscription_required" => SubscriptionRequired,
+          "bridge_disconnected" => BridgeDisconnected
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -124,6 +557,8 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `creating`
         attr_accessor :mutation_code
         # Date and time at which the mutation was created.
         # @return [Time]
@@ -133,34 +568,229 @@ module Seam
         date_accessor :scheduled_at
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        class ModifiedFields < BaseResource
-          # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+        # The access code's PIN rotates periodically when the code is renewed. Retrieve the latest code before each use.
+        class CodeRotatesPeriodically < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
-          attr_accessor :field
-          # The previous value of the field.
-          # @return [String, nil]
-          attr_accessor :from
-          # The new value of the field.
-          # @return [String, nil]
-          attr_accessor :to
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `code_rotates_periodically`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
         end
 
-        # List of fields that were changed externally, with their previous and new values.
-        # @return [Array<ModifiedFields>]
-        resource_list_accessor :modified_fields, ModifiedFields
-        # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
-        # @return [String, nil]
-        attr_accessor :change_type
+        # The device's time zone is unknown and this code's time frame crosses a daylight-saving transition in at least one plausible time zone. A 1-hour safety buffer has been applied to the side of the time frame affected by the transition (`ends_at` for spring-forward, `starts_at` for fall-back) so the code stays active through the shift — the code may be usable up to 1 hour beyond your requested window. Set the device's time zone via `/devices/report_provider_metadata` to clear the buffer and guarantee exact handling.
+        class TimeFrameAdjustedForUnknownTimeZone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_frame_adjusted_for_unknown_time_zone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Code was modified or removed externally after Seam successfully set it on the device. External modification is allowed for this code, so the externally modified state is being honored.
+        class ExternalModificationInEffect < Warnings
+          class ModifiedFields < BaseResource
+            # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            # @return [String]
+            attr_accessor :field
+            # The previous value of the field.
+            # @return [String, nil]
+            attr_accessor :from
+            # The new value of the field.
+            # @return [String, nil]
+            attr_accessor :to
+          end
+
+          # List of fields that were changed externally, with their previous and new values.
+          # @return [Array<ModifiedFields>]
+          resource_list_accessor :modified_fields, ModifiedFields
+          # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+          # @return [String, nil]
+          # Known values:
+          # - `modified`
+          # - `removed`
+          attr_accessor :change_type
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `external_modification_in_effect`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Delay in setting code on device.
+        class DelayInSettingOnDevice < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_setting_on_device`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Delay in removing code from device.
+        class DelayInRemovingFromDevice < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_removing_from_device`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Third-party integration detected that may cause access codes to fail.
+        class ThirdPartyIntegrationDetected < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `third_party_integration_detected`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Algopins must be used within 24 hours.
+        class IglooAlgopinMustBeUsedWithinN24Hours < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `igloo_algopin_must_be_used_within_24_hours`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Management was transferred to another workspace.
+        class ManagementTransferred < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `management_transferred`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # A backup access code has been pulled and is being used in place of this access code.
+        class UsingBackupAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `using_backup_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Access code is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # An unknown issue occurred with the access code.
+        class UnknownIssueWithAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `code_rotates_periodically`
+        # - `time_frame_adjusted_for_unknown_time_zone`
+        # - `external_modification_in_effect`
+        # - `delay_in_setting_on_device`
+        # - `delay_in_removing_from_device`
+        # - `third_party_integration_detected`
+        # - `igloo_algopin_must_be_used_within_24_hours`
+        # - `management_transferred`
+        # - `using_backup_access_code`
+        # - `being_deleted`
+        # - `unknown_issue_with_access_code`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time, nil]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "code_rotates_periodically" => CodeRotatesPeriodically,
+          "time_frame_adjusted_for_unknown_time_zone" => TimeFrameAdjustedForUnknownTimeZone,
+          "external_modification_in_effect" => ExternalModificationInEffect,
+          "delay_in_setting_on_device" => DelayInSettingOnDevice,
+          "delay_in_removing_from_device" => DelayInRemovingFromDevice,
+          "third_party_integration_detected" => ThirdPartyIntegrationDetected,
+          "igloo_algopin_must_be_used_within_24_hours" => IglooAlgopinMustBeUsedWithinN24Hours,
+          "management_transferred" => ManagementTransferred,
+          "using_backup_access_code" => UsingBackupAccessCode,
+          "being_deleted" => BeingDeleted,
+          "unknown_issue_with_access_code" => UnknownIssueWithAccessCode
+        }.freeze
       end
 
       # Metadata for a dormakaba Oracode managed access code. Only present for access codes from dormakaba Oracode devices.
@@ -219,9 +849,18 @@ module Seam
       attr_accessor :pulled_backup_access_code_id
       # Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/lifecycle-of-access-codes).
       # @return [String]
+      # Known values:
+      # - `setting`
+      # - `set`
+      # - `unset`
+      # - `removing`
+      # - `unknown`
       attr_accessor :status
       # Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
       # @return [String]
+      # Known values:
+      # - `time_bound`
+      # - `ongoing`
       attr_accessor :type
       # Unique identifier for the Seam workspace associated with the access code.
       # @return [String]

--- a/lib/seam/resources/access_grant.rb
+++ b/lib/seam/resources/access_grant.rb
@@ -4,19 +4,41 @@ module Seam
   module Resources
     # Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
     class AccessGrant < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that Seam could not create one or more of the requested access methods for the access grant.
+        class CannotCreateRequestedAccessMethods < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `cannot_create_requested_access_methods`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
+          # @return [Array<String>]
+          attr_accessor :missing_device_ids
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `cannot_create_requested_access_methods`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
-        # @return [Array<String>]
-        attr_accessor :missing_device_ids
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "cannot_create_requested_access_methods" => CannotCreateRequestedAccessMethods
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -58,6 +80,8 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `updating_spaces`
         attr_accessor :mutation_code
         # Date and time at which the mutation was created.
         # @return [Time]
@@ -79,51 +103,191 @@ module Seam
         attr_accessor :instant_key_max_use_count
         # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
         # @return [String]
+        # Known values:
+        # - `code`
+        # - `card`
+        # - `mobile_key`
+        # - `cloud_key`
         attr_accessor :mode
         # Date and time at which the requested access method was added to the Access Grant.
         # @return [Time]
         date_accessor :created_at
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        class FailedDevices < BaseResource
-          # Device whose access code could not be revoked.
-          # @return [String]
-          attr_accessor :device_id
-          # Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
-          # @return [String]
-          attr_accessor :error_code
-          # Human-readable description of why revocation failed.
+        # Indicates that the [access grant](https://docs.seam.co/use-cases/granting-access) is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
           attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
         end
 
-        # Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
-        # @return [Array<FailedDevices>]
-        resource_list_accessor :failed_devices, FailedDevices
-        # IDs of the access methods being updated.
-        # @return [Array<String>]
-        attr_accessor :access_method_ids
-        # @return [String]
-        attr_accessor :device_id
+        # Indicates that the access grant should have access to more locations than it currently does. Access methods are being created for the missing locations.
+        class UnderprovisionedAccess < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `underprovisioned_access`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access grant has access to locations it should not have. Access methods are being removed from the extra locations.
+        class OverprovisionedAccess < Warnings
+          class FailedDevices < BaseResource
+            # Device whose access code could not be revoked.
+            # @return [String]
+            attr_accessor :device_id
+            # Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
+            # @return [String]
+            attr_accessor :error_code
+            # Human-readable description of why revocation failed.
+            # @return [String]
+            attr_accessor :message
+          end
+
+          # Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+          # @return [Array<FailedDevices>]
+          resource_list_accessor :failed_devices, FailedDevices
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `overprovisioned_access`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access times for this [access grant](https://docs.seam.co/use-cases/granting-access) are being updated.
+        class UpdatingAccessTimes < Warnings
+          # IDs of the access methods being updated.
+          # @return [Array<String>]
+          attr_accessor :access_method_ids
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `updating_access_times`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the requested PIN code was already in use on a device, so a different code was assigned.
+        class RequestedCodeUnavailable < Warnings
+          # ID of the device where the requested code was unavailable.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # The new PIN code that was assigned instead.
+          # @return [String]
+          attr_accessor :new_code
+          # The originally requested PIN code that was unavailable.
+          # @return [String]
+          attr_accessor :original_code
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `requested_code_unavailable`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a device in the access grant does not support access codes and was excluded from code materialization.
+        class DeviceDoesNotSupportAccessCodes < Warnings
+          # ID of the device that does not support access codes.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_does_not_support_access_codes`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a device in the access grant cannot program an access code for the grant's time range because of device-specific time constraints.
+        class DeviceTimeConstraintsViolated < Warnings
+          # ID of the device whose time constraints the access grant violates.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Specific reason why the grant's times are not programmable on the device.
+          # @return [String]
+          # Known values:
+          # - `duration_exceeds_max`
+          # - `times_do_not_match_slots`
+          # - `ongoing_not_supported`
+          attr_accessor :reason
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_time_constraints_violated`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # The new PIN code that was assigned instead.
-        # @return [String]
-        attr_accessor :new_code
-        # The originally requested PIN code that was unavailable.
-        # @return [String]
-        attr_accessor :original_code
-        # Specific reason why the grant's times are not programmable on the device.
-        # @return [String]
-        attr_accessor :reason
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `underprovisioned_access`
+        # - `overprovisioned_access`
+        # - `updating_access_times`
+        # - `requested_code_unavailable`
+        # - `device_does_not_support_access_codes`
+        # - `device_time_constraints_violated`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "underprovisioned_access" => UnderprovisionedAccess,
+          "overprovisioned_access" => OverprovisionedAccess,
+          "updating_access_times" => UpdatingAccessTimes,
+          "requested_code_unavailable" => RequestedCodeUnavailable,
+          "device_does_not_support_access_codes" => DeviceDoesNotSupportAccessCodes,
+          "device_time_constraints_violated" => DeviceTimeConstraintsViolated
+        }.freeze
       end
 
       # Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).

--- a/lib/seam/resources/access_method.rb
+++ b/lib/seam/resources/access_method.rb
@@ -4,9 +4,27 @@ module Seam
   module Resources
     # Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
     class AccessMethod < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that Seam was unable to issue this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) before its access grant started, so the recipient may be unable to access the space. This usually points to a problem that needs attention, such as an offline or disconnected device. Seam keeps retrying, and this error clears automatically if the access method is eventually issued.
+        class FailedToIssue < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_issue`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `failed_to_issue`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -14,6 +32,10 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "failed_to_issue" => FailedToIssue
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -47,25 +69,100 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `provisioning_access`
         attr_accessor :mutation_code
         # Date and time at which the mutation was created.
         # @return [Time]
         date_accessor :created_at
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access times for this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) are being updated.
+        class UpdatingAccessTimes < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `updating_access_times`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that all attempts to create an access code on this device before the start time failed and a backup access code was used to ensure access was provided in time.
+        class PulledBackupAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # ID of the original access method from which this backup access method was split, if applicable.
+          # @return [String, nil]
+          attr_accessor :original_access_method_id
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `pulled_backup_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam has not yet issued this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant), even though its access grant is about to begin, so access may not be ready when the recipient arrives. Seam is still attempting to issue it, and this warning clears automatically once issuance succeeds.
+        class DelayInIssuing < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_issuing`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # ID of the original access method from which this backup access method was split, if applicable.
-        # @return [String, nil]
-        attr_accessor :original_access_method_id
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `updating_access_times`
+        # - `pulled_backup_access_code`
+        # - `delay_in_issuing`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "updating_access_times" => UpdatingAccessTimes,
+          "pulled_backup_access_code" => PulledBackupAccessCode,
+          "delay_in_issuing" => DelayInIssuing
+        }.freeze
       end
 
       # Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
@@ -112,6 +209,11 @@ module Seam
       attr_accessor :is_ready_for_encoding
       # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       # @return [String]
+      # Known values:
+      # - `code`
+      # - `card`
+      # - `mobile_key`
+      # - `cloud_key`
       attr_accessor :mode
       # ID of the Seam workspace associated with the access method.
       # @return [String]

--- a/lib/seam/resources/acs_access_group.rb
+++ b/lib/seam/resources/acs_access_group.rb
@@ -17,9 +17,27 @@ module Seam
         date_accessor :starts_at
       end
 
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that the [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/low-level-apis/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).
+        class FailedToCreateOnAcsSystem < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_create_on_acs_system`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `failed_to_create_on_acs_system`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -27,6 +45,10 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "failed_to_create_on_acs_system" => FailedToCreateOnAcsSystem
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -77,9 +99,14 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `creating`
         attr_accessor :mutation_code
         # Whether the user is scheduled to be added to or removed from this access group.
         # @return [String]
+        # Known values:
+        # - `adding`
+        # - `removing`
         attr_accessor :variant
         # Date and time at which the mutation was created.
         # @return [Time]
@@ -92,6 +119,9 @@ module Seam
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `unknown_issue_with_acs_access_group`
+        # - `being_deleted`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
@@ -111,6 +141,17 @@ module Seam
       # @return [Array<Warnings>]
       resource_list_accessor :warnings, Warnings
       # @return [String]
+      # Known values:
+      # - `pti_unit`
+      # - `pti_access_level`
+      # - `salto_ks_access_group`
+      # - `brivo_group`
+      # - `salto_space_group`
+      # - `dormakaba_community_access_group`
+      # - `dormakaba_ambiance_access_group`
+      # - `avigilon_alta_group`
+      # - `kisi_access_group`
+      # - `akiles_member_group`
       # @deprecated Use `external_type`.
       attr_accessor :access_group_type
       # @return [String]
@@ -130,6 +171,17 @@ module Seam
       attr_accessor :display_name
       # Brand-specific terminology for the access group type.
       # @return [String]
+      # Known values:
+      # - `pti_unit`
+      # - `pti_access_level`
+      # - `salto_ks_access_group`
+      # - `brivo_group`
+      # - `salto_space_group`
+      # - `dormakaba_community_access_group`
+      # - `dormakaba_ambiance_access_group`
+      # - `avigilon_alta_group`
+      # - `kisi_access_group`
+      # - `akiles_member_group`
       attr_accessor :external_type
       # Display name that corresponds to the brand-specific terminology for the access group type.
       # @return [String]

--- a/lib/seam/resources/acs_credential.rb
+++ b/lib/seam/resources/acs_credential.rb
@@ -53,6 +53,9 @@ module Seam
         attr_accessor :auto_join
         # Card function type in the Visionline access system.
         # @return [String, nil]
+        # Known values:
+        # - `guest`
+        # - `staff`
         attr_accessor :card_function_type
         # ID of the card in the Visionline access system.
         # @return [String, nil]
@@ -74,22 +77,146 @@ module Seam
         attr_accessor :joiner_acs_credential_ids
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is waiting to be issued.
+        class WaitingToBeIssued < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `waiting_to_be_issued`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the schedule of one of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials)'s children was modified externally.
+        class ScheduleExternallyModified < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `schedule_externally_modified`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the schedule of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.
+        class ScheduleModified < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `schedule_modified`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.
+        class UnknownIssueWithAcsCredential < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_acs_credential`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Access permissions for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.
+        class NeedsToBeReissued < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `needs_to_be_reissued`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the requested PIN code could not be used, so the access system assigned a different code. Give the guest the assigned code.
+        class RequestedCodeUnavailable < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # The PIN code that was assigned instead.
+          # @return [String]
+          attr_accessor :new_code
+          # The originally requested PIN code that could not be used.
+          # @return [String]
+          attr_accessor :original_code
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `requested_code_unavailable`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # The PIN code that was assigned instead.
-        # @return [String]
-        attr_accessor :new_code
-        # The originally requested PIN code that could not be used.
-        # @return [String]
-        attr_accessor :original_code
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `waiting_to_be_issued`
+        # - `schedule_externally_modified`
+        # - `schedule_modified`
+        # - `being_deleted`
+        # - `unknown_issue_with_acs_credential`
+        # - `needs_to_be_reissued`
+        # - `requested_code_unavailable`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "waiting_to_be_issued" => WaitingToBeIssued,
+          "schedule_externally_modified" => ScheduleExternallyModified,
+          "schedule_modified" => ScheduleModified,
+          "being_deleted" => BeingDeleted,
+          "unknown_issue_with_acs_credential" => UnknownIssueWithAcsCredential,
+          "needs_to_be_reissued" => NeedsToBeReissued,
+          "requested_code_unavailable" => RequestedCodeUnavailable
+        }.freeze
       end
 
       # Akiles-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
@@ -109,6 +236,11 @@ module Seam
       resource_list_accessor :warnings, Warnings
       # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       # @return [String]
+      # Known values:
+      # - `code`
+      # - `card`
+      # - `mobile_key`
+      # - `cloud_key`
       attr_accessor :access_method
       # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
       # @return [String]
@@ -139,6 +271,21 @@ module Seam
       attr_accessor :ends_at
       # Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
       # @return [String, nil]
+      # Known values:
+      # - `pti_card`
+      # - `brivo_credential`
+      # - `hid_credential`
+      # - `visionline_card`
+      # - `salto_ks_credential`
+      # - `assa_abloy_vostio_key`
+      # - `salto_space_key`
+      # - `latch_access`
+      # - `dormakaba_ambiance_credential`
+      # - `hotek_card`
+      # - `salto_ks_tag`
+      # - `avigilon_alta_credential`
+      # - `kisi_credential`
+      # - `akiles_credential`
       attr_accessor :external_type
       # Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
       # @return [String, nil]

--- a/lib/seam/resources/acs_encoder.rb
+++ b/lib/seam/resources/acs_encoder.rb
@@ -20,6 +20,8 @@ module Seam
       class Errors < BaseResource
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `acs_encoder_removed`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]

--- a/lib/seam/resources/acs_entrance.rb
+++ b/lib/seam/resources/acs_entrance.rb
@@ -39,6 +39,11 @@ module Seam
         attr_accessor :door_number
         # Type of the door in the Vostio access system.
         # @return [String, nil]
+        # Known values:
+        # - `CommonDoor`
+        # - `EntranceDoor`
+        # - `GuestDoor`
+        # - `Elevator`
         attr_accessor :door_type
         # PMS ID of the door in the Vostio access system.
         # @return [String, nil]
@@ -190,6 +195,10 @@ module Seam
           attr_accessor :visionline_door_profile_id
           # Door profile type in the Visionline access system.
           # @return [String, nil]
+          # Known values:
+          # - `BLE`
+          # - `commonDoor`
+          # - `touch`
           attr_accessor :visionline_door_profile_type
         end
 
@@ -198,22 +207,118 @@ module Seam
         resource_list_accessor :profiles, Profiles
         # Category of the door in the Visionline access system.
         # @return [String, nil]
+        # Known values:
+        # - `entrance`
+        # - `guest`
+        # - `elevator reader`
+        # - `common`
+        # - `common (PMS)`
         attr_accessor :door_category
         # Name of the door in the Visionline access system.
         # @return [String, nil]
         attr_accessor :door_name
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that a change in the reported device model has been detected for this Salto KS entrance, which may occur after an IQ hub reset. Access code support may be affected. See https://help.getseam.com/articles/5098842588-salto-ks-lock-loses-access-code-support for troubleshooting steps.
+        class SaltoKsEntranceAccessCodeSupportRemoved < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_entrance_access_code_support_removed`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that this entrance shares a zone with other entrances in Avigilon Alta and cannot be added to an access group individually.
+        class EntranceSharesZone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `entrance_shares_zone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that this entrance requires additional configuration in the access control system before Seam can fully manage it.
+        class EntranceSetupRequired < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `entrance_setup_required`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that this entrance is in privacy mode. When privacy mode is enabled, access codes, mobile keys, and remote unlocks will not work unless the user has admin access.
+        class SaltoKsPrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that this entrance is in privacy mode. When privacy mode is enabled, access codes, mobile keys, and remote unlocks will not work unless the user has admin access.
+        class PrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `salto_ks_entrance_access_code_support_removed`
+        # - `entrance_shares_zone`
+        # - `entrance_setup_required`
+        # - `salto_ks_privacy_mode`
+        # - `privacy_mode`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "salto_ks_entrance_access_code_support_removed" => SaltoKsEntranceAccessCodeSupportRemoved,
+          "entrance_shares_zone" => EntranceSharesZone,
+          "entrance_setup_required" => EntranceSetupRequired,
+          "salto_ks_privacy_mode" => SaltoKsPrivacyMode,
+          "privacy_mode" => PrivacyMode
+        }.freeze
       end
 
       # Akiles-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).

--- a/lib/seam/resources/acs_system.rb
+++ b/lib/seam/resources/acs_system.rb
@@ -8,19 +8,182 @@ module Seam
     #
     # For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
     class AcsSystem < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
+        # This error might also occur if Seam Bridge is connected to the wrong [workspace](https://docs.seam.co/core-concepts/workspaces).
+        # See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class SeamBridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `seam_bridge_disconnected`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
+        # See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) is functioning correctly and the Seam API can communicate with Seam Bridge, but the Seam API cannot connect to the on-premises [Visionline access control system](https://docs.seam.co/device-and-system-integration-guides/assa-abloy-visionline-access-control-system).
+        # For example, the IP address of the on-premises access control system may be set incorrectly within the Seam [workspace](https://docs.seam.co/core-concepts/workspaces).
+        # See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-visionline_instance_unreachable).
+        class VisionlineInstanceUnreachable < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `visionline_instance_unreachable`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the maximum number of users allowed for the site has been reached. This means that new access codes cannot be created. Contact Salto support to increase the user limit.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam's integration user does not have sufficient permissions on the provider's system backing this [access control system](https://docs.seam.co/low-level-apis/access-systems). Access cannot be managed until permissions are restored. See the error message for specifics, then either reauthorize the connected account in Seam or grant the integration user the required permissions in the provider's system.
+        class InsufficientPermissions < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `insufficient_permissions`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access control system](https://docs.seam.co/low-level-apis/access-systems) has been disconnected. See [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system) to resolve the issue.
+        class AcsSystemDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `acs_system_disconnected`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the login credentials are invalid. Reconnect the account using a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) to restore access.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access control system](https://docs.seam.co/low-level-apis/access-systems) has lost its Salto KS certification. Contact [support](mailto:support@seam.co) to regain access.
+        class SaltoKsCertificationExpired < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_certification_expired`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access control system provider's service is temporarily unavailable. Seam will automatically retry and reconnect when the service becomes available again.
+        class ProviderServiceUnavailable < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `provider_service_unavailable`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `seam_bridge_disconnected`
+        # - `bridge_disconnected`
+        # - `visionline_instance_unreachable`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `insufficient_permissions`
+        # - `acs_system_disconnected`
+        # - `account_disconnected`
+        # - `salto_ks_certification_expired`
+        # - `provider_service_unavailable`
         attr_accessor :error_code
-        # Indicates whether the error is related to the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
-        # @return [Boolean, nil]
-        attr_accessor :is_bridge_error
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "seam_bridge_disconnected" => SeamBridgeDisconnected,
+          "bridge_disconnected" => BridgeDisconnected,
+          "visionline_instance_unreachable" => VisionlineInstanceUnreachable,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "insufficient_permissions" => InsufficientPermissions,
+          "acs_system_disconnected" => AcsSystemDisconnected,
+          "account_disconnected" => AccountDisconnected,
+          "salto_ks_certification_expired" => SaltoKsCertificationExpired,
+          "provider_service_unavailable" => ProviderServiceUnavailable
+        }.freeze
       end
 
       class Location < BaseResource
@@ -41,19 +204,92 @@ module Seam
         attr_accessor :system_id
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the Salto KS site has exceeded 80% of the maximum number of allowed users. Increase your subscription limit or delete some users from your site to rectify the issue.
+        class SaltoKsSubscriptionLimitAlmostReached < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_almost_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates the [access control system](https://docs.seam.co/low-level-apis/access-systems) time zone could not be determined because the reported physical location does not match the time zone configured on the physical [ACS entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        class TimeZoneDoesNotMatchLocation < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [Array<String>]
+          # @deprecated this field is deprecated.
+          attr_accessor :misconfigured_acs_entrance_ids
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_zone_does_not_match_location`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access control system requires additional setup before it can be fully operational. Follow the instructions in the warning message to complete the setup.
+        class SetupRequired < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `setup_required`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam encountered an unexpected error while syncing this [access control system](https://docs.seam.co/low-level-apis/access-systems), so its users, credentials, and access groups may be out of date. Seam retries on every sync cycle and clears this warning once a sync succeeds; if it persists, contact [support](mailto:support@seam.co).
+        class UnknownIssueWithAcsSystem < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_acs_system`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # @return [Array<String>]
-        # @deprecated this field is deprecated.
-        attr_accessor :misconfigured_acs_entrance_ids
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `salto_ks_subscription_limit_almost_reached`
+        # - `time_zone_does_not_match_location`
+        # - `setup_required`
+        # - `unknown_issue_with_acs_system`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "salto_ks_subscription_limit_almost_reached" => SaltoKsSubscriptionLimitAlmostReached,
+          "time_zone_does_not_match_location" => TimeZoneDoesNotMatchLocation,
+          "setup_required" => SetupRequired,
+          "unknown_issue_with_acs_system" => UnknownIssueWithAcsSystem
+        }.freeze
       end
 
       # Location information for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
@@ -89,6 +325,24 @@ module Seam
       attr_accessor :default_credential_manager_acs_system_id
       # Brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
       # @return [String, nil]
+      # Known values:
+      # - `pti_site`
+      # - `avigilon_alta_org`
+      # - `salto_ks_site`
+      # - `salto_space_system`
+      # - `brivo_account`
+      # - `hid_credential_manager_organization`
+      # - `visionline_system`
+      # - `assa_abloy_credential_service`
+      # - `latch_building`
+      # - `dormakaba_community_site`
+      # - `dormakaba_ambiance_site`
+      # - `legic_connect_credential_service`
+      # - `assa_abloy_vostio`
+      # - `assa_abloy_vostio_credential_service`
+      # - `hotek_site`
+      # - `kisi_organization`
+      # - `akiles_organization`
       attr_accessor :external_type
       # Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
       # @return [String, nil]
@@ -106,6 +360,24 @@ module Seam
       # @return [String]
       attr_accessor :name
       # @return [String, nil]
+      # Known values:
+      # - `pti_site`
+      # - `avigilon_alta_org`
+      # - `salto_ks_site`
+      # - `salto_space_system`
+      # - `brivo_account`
+      # - `hid_credential_manager_organization`
+      # - `visionline_system`
+      # - `assa_abloy_credential_service`
+      # - `latch_building`
+      # - `dormakaba_community_site`
+      # - `dormakaba_ambiance_site`
+      # - `legic_connect_credential_service`
+      # - `assa_abloy_vostio`
+      # - `assa_abloy_vostio_credential_service`
+      # - `hotek_site`
+      # - `kisi_organization`
+      # - `akiles_organization`
       # @deprecated Use `external_type`.
       attr_accessor :system_type
       # @return [String, nil]

--- a/lib/seam/resources/acs_user.rb
+++ b/lib/seam/resources/acs_user.rb
@@ -17,8 +17,100 @@ module Seam
         date_accessor :starts_at
       end
 
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/low-level-apis/access-systems) outside of Seam.
+        class DeletedExternally < Errors
+          # @return [String]
+          # Known values:
+          # - `deleted_externally`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was not created on the [access system](https://docs.seam.co/low-level-apis/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).
+        class FailedToCreateOnAcsSystem < Errors
+          # @return [String]
+          # Known values:
+          # - `failed_to_create_on_acs_system`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/low-level-apis/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).
+        class FailedToUpdateOnAcsSystem < Errors
+          # @return [String]
+          # Known values:
+          # - `failed_to_update_on_acs_system`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/low-level-apis/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).
+        class FailedToDeleteOnAcsSystem < Errors
+          # @return [String]
+          # Known values:
+          # - `failed_to_delete_on_acs_system`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).
+        class LatchConflictWithResidentUser < Errors
+          # @return [String]
+          # Known values:
+          # - `latch_conflict_with_resident_user`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # @return [String]
+        # Known values:
+        # - `deleted_externally`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `failed_to_create_on_acs_system`
+        # - `failed_to_update_on_acs_system`
+        # - `failed_to_delete_on_acs_system`
+        # - `latch_conflict_with_resident_user`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -26,6 +118,15 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "deleted_externally" => DeletedExternally,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "failed_to_create_on_acs_system" => FailedToCreateOnAcsSystem,
+          "failed_to_update_on_acs_system" => FailedToUpdateOnAcsSystem,
+          "failed_to_delete_on_acs_system" => FailedToDeleteOnAcsSystem,
+          "latch_conflict_with_resident_user" => LatchConflictWithResidentUser
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -92,9 +193,14 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `creating`
         attr_accessor :mutation_code
         # Whether the user is scheduled to be added to or removed from the access group.
         # @return [String]
+        # Known values:
+        # - `adding`
+        # - `removing`
         attr_accessor :variant
         # Date and time at which the mutation was created.
         # @return [Time]
@@ -119,15 +225,100 @@ module Seam
         attr_accessor :user_id
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/low-level-apis/access-systems). This is a temporary state, and the access system user will be deleted shortly.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.
+        class SaltoKsUserNotSubscribed < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [String]
+          # Known values:
+          # - `salto_ks_user_not_subscribed`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) exists but is not currently able to gain access—for example, because their access schedule has not started yet or has ended, the access system has reached its limit for active users, or they have been unsubscribed or deactivated. Refer to the warning message for the provider-specific reason. This is distinct from `is_suspended`, which indicates the user has been explicitly blocked.
+        class AcsUserInactive < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [String]
+          # Known values:
+          # - `acs_user_inactive`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.
+        class UnknownIssueWithAcsUser < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_acs_user`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.
+        class LatchResidentUser < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # @return [String]
+          # Known values:
+          # - `latch_resident_user`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `salto_ks_user_not_subscribed`
+        # - `acs_user_inactive`
+        # - `unknown_issue_with_acs_user`
+        # - `latch_resident_user`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "salto_ks_user_not_subscribed" => SaltoKsUserNotSubscribed,
+          "acs_user_inactive" => AcsUserInactive,
+          "unknown_issue_with_acs_user" => UnknownIssueWithAcsUser,
+          "latch_resident_user" => LatchResidentUser
+        }.freeze
       end
 
       # `starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/low-level-apis/access-systems/user-management) access.
@@ -168,6 +359,16 @@ module Seam
       attr_accessor :email_address
       # Brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
       # @return [String, nil]
+      # Known values:
+      # - `pti_user`
+      # - `brivo_user`
+      # - `hid_credential_manager_user`
+      # - `salto_site_user`
+      # - `latch_user`
+      # - `dormakaba_community_user`
+      # - `salto_space_user`
+      # - `avigilon_alta_user`
+      # - `kisi_user`
       attr_accessor :external_type
       # Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
       # @return [String, nil]

--- a/lib/seam/resources/action_attempt.rb
+++ b/lib/seam/resources/action_attempt.rb
@@ -2,78 +2,446 @@
 
 module Seam
   module Resources
-    # Locking a door is pending.
+    # Represents a Seam action attempt. Known action types load as subclasses; unknown action types remain ActionAttempt instances for forward compatibility.
     class ActionAttempt < BaseResource
       class Error < BaseResource
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # @return [String]
-        attr_accessor :type
       end
 
       class Result < BaseResource
-        class AcsCredentialOnEncoder < BaseResource
-          class VisionlineMetadata < BaseResource
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is cancelled.
-            # @return [Boolean, nil]
-            attr_accessor :cancelled
-            # Format of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [String, nil]
-            attr_accessor :card_format
-            # Holder of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [String, nil]
-            attr_accessor :card_holder
-            # Card ID for the Visionline card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [String, nil]
-            attr_accessor :card_id
-            # IDs of the common [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [Array<String>]
-            attr_accessor :common_acs_entrance_ids
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is discarded.
-            # @return [Boolean, nil]
-            attr_accessor :discarded
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is expired.
-            # @return [Boolean, nil]
-            attr_accessor :expired
-            # IDs of the guest [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [Array<String>]
-            attr_accessor :guest_acs_entrance_ids
-            # Number of issued cards associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-            # @return [Float, nil]
-            attr_accessor :number_of_issued_cards
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overridden.
-            # @return [Boolean, nil]
-            attr_accessor :overridden
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overwritten.
-            # @return [Boolean, nil]
-            attr_accessor :overwritten
-            # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is pending auto-update.
-            # @return [Boolean, nil]
-            attr_accessor :pending_auto_update
-          end
+      end
 
-          # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-          # @return [VisionlineMetadata, nil]
-          resource_accessor :visionline_metadata, VisionlineMetadata
-          # A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-          # @return [String, nil]
-          attr_accessor :card_number
-          # Indicates whether the credential has been issued (encoded onto a card).
-          # @return [Boolean, nil]
-          attr_accessor :is_issued
-          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
-          # @return [Time, nil]
-          date_accessor :created_at
-          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) will stop being usable.
-          # @return [Time, nil]
-          date_accessor :ends_at
-          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) becomes usable.
-          # @return [Time, nil]
-          date_accessor :starts_at
+      # Locking a door is pending.
+      class LockDoor < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
         end
 
-        class AcsCredentialOnSeam < BaseResource
+        class Result < BaseResource
+          # Indicates whether the device confirmed that the lock action occurred.
+          # @return [Boolean, nil]
+          attr_accessor :was_confirmed_by_device
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of locking a door.
+        # @return [String]
+        # Known values:
+        # - `LOCK_DOOR`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Unlocking a door is pending.
+      class UnlockDoor < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          # Indicates whether the device confirmed that the unlock action occurred.
+          # @return [Boolean, nil]
+          attr_accessor :was_confirmed_by_device
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of unlocking a door.
+        # @return [String]
+        # Known values:
+        # - `UNLOCK_DOOR`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Reading credential data from the physical encoder is pending.
+      class ScanCredential < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Error type to indicate that the Seam Bridge is disconnected or cannot reach the access control system.
+          # @return [String]
+          # Known values:
+          # - `uncategorized_error`
+          # - `action_attempt_expired`
+          # - `no_credential_on_encoder`
+          # - `encoder_not_online`
+          # - `encoder_communication_timeout`
+          # - `bridge_disconnected`
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          class AcsCredentialOnEncoder < BaseResource
+            class VisionlineMetadata < BaseResource
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is cancelled.
+              # @return [Boolean, nil]
+              attr_accessor :cancelled
+              # Format of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [String, nil]
+              # Known values:
+              # - `TLCode`
+              # - `rfid48`
+              attr_accessor :card_format
+              # Holder of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [String, nil]
+              attr_accessor :card_holder
+              # Card ID for the Visionline card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [String, nil]
+              attr_accessor :card_id
+              # IDs of the common [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [Array<String>]
+              attr_accessor :common_acs_entrance_ids
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is discarded.
+              # @return [Boolean, nil]
+              attr_accessor :discarded
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is expired.
+              # @return [Boolean, nil]
+              attr_accessor :expired
+              # IDs of the guest [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [Array<String>]
+              attr_accessor :guest_acs_entrance_ids
+              # Number of issued cards associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+              # @return [Float, nil]
+              attr_accessor :number_of_issued_cards
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overridden.
+              # @return [Boolean, nil]
+              attr_accessor :overridden
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overwritten.
+              # @return [Boolean, nil]
+              attr_accessor :overwritten
+              # Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is pending auto-update.
+              # @return [Boolean, nil]
+              attr_accessor :pending_auto_update
+            end
+
+            # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [VisionlineMetadata, nil]
+            resource_accessor :visionline_metadata, VisionlineMetadata
+            # A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String, nil]
+            attr_accessor :card_number
+            # Indicates whether the credential has been issued (encoded onto a card).
+            # @return [Boolean, nil]
+            attr_accessor :is_issued
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+            # @return [Time, nil]
+            date_accessor :created_at
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) will stop being usable.
+            # @return [Time, nil]
+            date_accessor :ends_at
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) becomes usable.
+            # @return [Time, nil]
+            date_accessor :starts_at
+          end
+
+          class AcsCredentialOnSeam < BaseResource
+            class AkilesMetadata < BaseResource
+              # ID of the Akiles member PIN.
+              # @return [String, nil]
+              attr_accessor :member_pin_id
+            end
+
+            class AssaAbloyVostioMetadata < BaseResource
+              # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+              # @return [Boolean, nil]
+              attr_accessor :auto_join
+              # Names of the doors to which to grant access in the Vostio access system.
+              # @return [Array<String>]
+              attr_accessor :door_names
+              # Endpoint ID in the Vostio access system.
+              # @return [String, nil]
+              attr_accessor :endpoint_id
+              # Key ID in the Vostio access system.
+              # @return [String, nil]
+              attr_accessor :key_id
+              # Key issuing request ID in the Vostio access system.
+              # @return [String, nil]
+              attr_accessor :key_issuing_request_id
+              # IDs of the guest entrances to override in the Vostio access system.
+              # @return [Array<String>]
+              attr_accessor :override_guest_acs_entrance_ids
+            end
+
+            class Errors < BaseResource
+              # @return [String]
+              attr_accessor :error_code
+              # @return [String]
+              attr_accessor :message
+              # Date and time at which Seam created the error.
+              # @return [Time]
+              date_accessor :created_at
+            end
+
+            class VisionlineMetadata < BaseResource
+              # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+              # @return [Boolean, nil]
+              attr_accessor :auto_join
+              # Card function type in the Visionline access system.
+              # @return [String, nil]
+              # Known values:
+              # - `guest`
+              # - `staff`
+              attr_accessor :card_function_type
+              # ID of the card in the Visionline access system.
+              # @return [String, nil]
+              attr_accessor :card_id
+              # Common entrance IDs in the Visionline access system.
+              # @return [Array<String>]
+              attr_accessor :common_acs_entrance_ids
+              # ID of the credential in the Visionline access system.
+              # @return [String, nil]
+              attr_accessor :credential_id
+              # Guest entrance IDs in the Visionline access system.
+              # @return [Array<String>]
+              attr_accessor :guest_acs_entrance_ids
+              # Indicates whether the credential is valid.
+              # @return [Boolean, nil]
+              attr_accessor :is_valid
+              # IDs of the credentials to which you want to join.
+              # @return [Array<String>]
+              attr_accessor :joiner_acs_credential_ids
+            end
+
+            class Warnings < BaseResource
+              # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+              # @return [String]
+              attr_accessor :message
+              # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+              # @return [String]
+              # Known values:
+              # - `waiting_to_be_issued`
+              # - `schedule_externally_modified`
+              # - `schedule_modified`
+              # - `being_deleted`
+              # - `unknown_issue_with_acs_credential`
+              # - `needs_to_be_reissued`
+              # - `requested_code_unavailable`
+              attr_accessor :warning_code
+              # The PIN code that was assigned instead.
+              # @return [String, nil]
+              attr_accessor :new_code
+              # The originally requested PIN code that could not be used.
+              # @return [String, nil]
+              attr_accessor :original_code
+              # Date and time at which Seam created the warning.
+              # @return [Time]
+              date_accessor :created_at
+            end
+
+            # Akiles-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [AkilesMetadata, nil]
+            resource_accessor :akiles_metadata, AkilesMetadata
+            # Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [AssaAbloyVostioMetadata, nil]
+            resource_accessor :assa_abloy_vostio_metadata, AssaAbloyVostioMetadata
+            # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [VisionlineMetadata, nil]
+            resource_accessor :visionline_metadata, VisionlineMetadata
+            # Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [Array<Errors>]
+            resource_list_accessor :errors, Errors
+            # Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [Array<Warnings>]
+            resource_list_accessor :warnings, Warnings
+            # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            # @return [String]
+            # Known values:
+            # - `code`
+            # - `card`
+            # - `mobile_key`
+            # - `cloud_key`
+            attr_accessor :access_method
+            # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String]
+            attr_accessor :acs_credential_id
+            # ID of the credential pool to which the credential belongs.
+            # @return [String, nil]
+            attr_accessor :acs_credential_pool_id
+            # ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String]
+            attr_accessor :acs_system_id
+            # ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+            # @return [String, nil]
+            attr_accessor :acs_user_id
+            # Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String, nil]
+            attr_accessor :card_number
+            # Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String, nil]
+            attr_accessor :code
+            # ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+            # @return [String]
+            attr_accessor :connected_account_id
+            # Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+            # @return [String]
+            attr_accessor :display_name
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            # @return [String, nil]
+            attr_accessor :ends_at
+            # Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+            # @return [String, nil]
+            # Known values:
+            # - `pti_card`
+            # - `brivo_credential`
+            # - `hid_credential`
+            # - `visionline_card`
+            # - `salto_ks_credential`
+            # - `assa_abloy_vostio_key`
+            # - `salto_space_key`
+            # - `latch_access`
+            # - `dormakaba_ambiance_credential`
+            # - `hotek_card`
+            # - `salto_ks_tag`
+            # - `avigilon_alta_credential`
+            # - `kisi_credential`
+            # - `akiles_credential`
+            attr_accessor :external_type
+            # Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+            # @return [String, nil]
+            attr_accessor :external_type_display_name
+            # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+            # @return [Boolean, nil]
+            attr_accessor :is_issued
+            # Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+            # @return [Boolean, nil]
+            attr_accessor :is_latest_desired_state_synced_with_provider
+            # @return [Boolean]
+            attr_accessor :is_managed
+            # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+            # @return [Boolean, nil]
+            attr_accessor :is_multi_phone_sync_credential
+            # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+            # @return [Boolean, nil]
+            attr_accessor :is_one_time_use
+            # ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String, nil]
+            attr_accessor :parent_acs_credential_id
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            # @return [String, nil]
+            attr_accessor :starts_at
+            # ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+            # @return [String, nil]
+            attr_accessor :user_identity_id
+            # ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+            # @return [String]
+            attr_accessor :workspace_id
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+            # @return [Time]
+            date_accessor :created_at
+            # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+            # @return [Time, nil]
+            date_accessor :issued_at
+            # Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+            # @return [Time, nil]
+            date_accessor :latest_desired_state_synced_with_provider_at
+          end
+
+          class Warnings < BaseResource
+            # Indicates a warning related to scanning a credential.
+            # @return [String]
+            # Known values:
+            # - `acs_credential_on_encoder_out_of_sync`
+            # - `acs_credential_on_seam_not_found`
+            attr_accessor :warning_code
+            # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            # @return [String]
+            attr_accessor :warning_message
+          end
+
+          # Snapshot of credential data read from the physical encoder.
+          # @return [AcsCredentialOnEncoder, nil]
+          resource_accessor :acs_credential_on_encoder, AcsCredentialOnEncoder
+          # Corresponding credential data as stored on Seam and the access system.
+          # @return [AcsCredentialOnSeam, nil]
+          resource_accessor :acs_credential_on_seam, AcsCredentialOnSeam
+          # Warnings related to scanning the credential, such as mismatches between the credential data currently encoded on the card and the corresponding data stored on Seam and the access system.
+          # @return [Array<Warnings>]
+          resource_list_accessor :warnings, Warnings
+        end
+
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of scanning a card. If the attempt was successful, includes a snapshot of credential data read from the physical encoder, the corresponding data stored on Seam and the access system, and any associated warnings.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of scanning a credential.
+        # @return [String]
+        # Known values:
+        # - `SCAN_CREDENTIAL`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Encoding credential data from the physical encoder onto a card is pending.
+      class EncodeCredential < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Error type to indicate that the credential was deleted and can no longer be encoded.
+          # @return [String]
+          # Known values:
+          # - `uncategorized_error`
+          # - `action_attempt_expired`
+          # - `no_credential_on_encoder`
+          # - `incompatible_card_format`
+          # - `credential_cannot_be_reissued`
+          # - `encoder_not_online`
+          # - `encoder_communication_timeout`
+          # - `bridge_disconnected`
+          # - `encoding_interrupted`
+          # - `credential_deleted`
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
           class AkilesMetadata < BaseResource
             # ID of the Akiles member PIN.
             # @return [String, nil]
@@ -117,6 +485,9 @@ module Seam
             attr_accessor :auto_join
             # Card function type in the Visionline access system.
             # @return [String, nil]
+            # Known values:
+            # - `guest`
+            # - `staff`
             attr_accessor :card_function_type
             # ID of the card in the Visionline access system.
             # @return [String, nil]
@@ -144,6 +515,14 @@ module Seam
             attr_accessor :message
             # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
             # @return [String]
+            # Known values:
+            # - `waiting_to_be_issued`
+            # - `schedule_externally_modified`
+            # - `schedule_modified`
+            # - `being_deleted`
+            # - `unknown_issue_with_acs_credential`
+            # - `needs_to_be_reissued`
+            # - `requested_code_unavailable`
             attr_accessor :warning_code
             # The PIN code that was assigned instead.
             # @return [String, nil]
@@ -173,6 +552,11 @@ module Seam
           resource_list_accessor :warnings, Warnings
           # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
           # @return [String]
+          # Known values:
+          # - `code`
+          # - `card`
+          # - `mobile_key`
+          # - `cloud_key`
           attr_accessor :access_method
           # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
           # @return [String]
@@ -203,6 +587,21 @@ module Seam
           attr_accessor :ends_at
           # Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
           # @return [String, nil]
+          # Known values:
+          # - `pti_card`
+          # - `brivo_credential`
+          # - `hid_credential`
+          # - `visionline_card`
+          # - `salto_ks_credential`
+          # - `assa_abloy_vostio_key`
+          # - `salto_space_key`
+          # - `latch_access`
+          # - `dormakaba_ambiance_credential`
+          # - `hotek_card`
+          # - `salto_ks_tag`
+          # - `avigilon_alta_credential`
+          # - `kisi_credential`
+          # - `akiles_credential`
           attr_accessor :external_type
           # Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
           # @return [String, nil]
@@ -244,266 +643,1045 @@ module Seam
           date_accessor :latest_desired_state_synced_with_provider_at
         end
 
-        class AkilesMetadata < BaseResource
-          # ID of the Akiles member PIN.
-          # @return [String, nil]
-          attr_accessor :member_pin_id
-        end
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of an encoding attempt. If the attempt was successful, includes the credential data that was encoded onto the card.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of encoding credential data from the physical encoder onto a card.
+        # @return [String]
+        # Known values:
+        # - `ENCODE_CREDENTIAL`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
 
-        class AssaAbloyVostioMetadata < BaseResource
-          # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
-          # @return [Boolean, nil]
-          attr_accessor :auto_join
-          # Names of the doors to which to grant access in the Vostio access system.
-          # @return [Array<String>]
-          attr_accessor :door_names
-          # Endpoint ID in the Vostio access system.
-          # @return [String, nil]
-          attr_accessor :endpoint_id
-          # Key ID in the Vostio access system.
-          # @return [String, nil]
-          attr_accessor :key_id
-          # Key issuing request ID in the Vostio access system.
-          # @return [String, nil]
-          attr_accessor :key_issuing_request_id
-          # IDs of the guest entrances to override in the Vostio access system.
-          # @return [Array<String>]
-          attr_accessor :override_guest_acs_entrance_ids
-        end
-
-        class Errors < BaseResource
-          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-          # @return [String]
-          attr_accessor :error_code
+      # Scanning a physical card and assigning the credential is pending.
+      class ScanToAssignCredential < ActionAttempt
+        class Error < BaseResource
           # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
           attr_accessor :message
-          # Date and time at which Seam created the error.
-          # @return [Time]
-          date_accessor :created_at
+          # Error type to indicate that there is no credential on the encoder.
+          # @return [String]
+          # Known values:
+          # - `uncategorized_error`
+          # - `action_attempt_expired`
+          # - `no_credential_on_encoder`
+          attr_accessor :type
         end
 
-        class PendingMutations < BaseResource
-          class From < BaseResource
-            # Previous end time for access.
-            # @return [Time, nil]
-            date_accessor :ends_at
-            # Previous start time for access.
-            # @return [Time, nil]
-            date_accessor :starts_at
+        class Result < BaseResource
+          class AkilesMetadata < BaseResource
+            # ID of the Akiles member PIN.
+            # @return [String, nil]
+            attr_accessor :member_pin_id
           end
 
-          class To < BaseResource
-            # New end time for access.
-            # @return [Time, nil]
-            date_accessor :ends_at
-            # New start time for access.
-            # @return [Time, nil]
-            date_accessor :starts_at
+          class AssaAbloyVostioMetadata < BaseResource
+            # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+            # @return [Boolean, nil]
+            attr_accessor :auto_join
+            # Names of the doors to which to grant access in the Vostio access system.
+            # @return [Array<String>]
+            attr_accessor :door_names
+            # Endpoint ID in the Vostio access system.
+            # @return [String, nil]
+            attr_accessor :endpoint_id
+            # Key ID in the Vostio access system.
+            # @return [String, nil]
+            attr_accessor :key_id
+            # Key issuing request ID in the Vostio access system.
+            # @return [String, nil]
+            attr_accessor :key_issuing_request_id
+            # IDs of the guest entrances to override in the Vostio access system.
+            # @return [Array<String>]
+            attr_accessor :override_guest_acs_entrance_ids
           end
 
-          # Previous access time configuration.
-          # @return [From]
-          resource_accessor :from, From
-          # New access time configuration.
-          # @return [To]
-          resource_accessor :to, To
-          # Detailed description of the mutation.
+          class Errors < BaseResource
+            # @return [String]
+            attr_accessor :error_code
+            # @return [String]
+            attr_accessor :message
+            # Date and time at which Seam created the error.
+            # @return [Time]
+            date_accessor :created_at
+          end
+
+          class VisionlineMetadata < BaseResource
+            # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+            # @return [Boolean, nil]
+            attr_accessor :auto_join
+            # Card function type in the Visionline access system.
+            # @return [String, nil]
+            # Known values:
+            # - `guest`
+            # - `staff`
+            attr_accessor :card_function_type
+            # ID of the card in the Visionline access system.
+            # @return [String, nil]
+            attr_accessor :card_id
+            # Common entrance IDs in the Visionline access system.
+            # @return [Array<String>]
+            attr_accessor :common_acs_entrance_ids
+            # ID of the credential in the Visionline access system.
+            # @return [String, nil]
+            attr_accessor :credential_id
+            # Guest entrance IDs in the Visionline access system.
+            # @return [Array<String>]
+            attr_accessor :guest_acs_entrance_ids
+            # Indicates whether the credential is valid.
+            # @return [Boolean, nil]
+            attr_accessor :is_valid
+            # IDs of the credentials to which you want to join.
+            # @return [Array<String>]
+            attr_accessor :joiner_acs_credential_ids
+          end
+
+          class Warnings < BaseResource
+            # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            # @return [String]
+            attr_accessor :message
+            # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+            # @return [String]
+            # Known values:
+            # - `waiting_to_be_issued`
+            # - `schedule_externally_modified`
+            # - `schedule_modified`
+            # - `being_deleted`
+            # - `unknown_issue_with_acs_credential`
+            # - `needs_to_be_reissued`
+            # - `requested_code_unavailable`
+            attr_accessor :warning_code
+            # The PIN code that was assigned instead.
+            # @return [String, nil]
+            attr_accessor :new_code
+            # The originally requested PIN code that could not be used.
+            # @return [String, nil]
+            attr_accessor :original_code
+            # Date and time at which Seam created the warning.
+            # @return [Time]
+            date_accessor :created_at
+          end
+
+          # Akiles-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [AkilesMetadata, nil]
+          resource_accessor :akiles_metadata, AkilesMetadata
+          # Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [AssaAbloyVostioMetadata, nil]
+          resource_accessor :assa_abloy_vostio_metadata, AssaAbloyVostioMetadata
+          # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [VisionlineMetadata, nil]
+          resource_accessor :visionline_metadata, VisionlineMetadata
+          # Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [Array<Errors>]
+          resource_list_accessor :errors, Errors
+          # Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [Array<Warnings>]
+          resource_list_accessor :warnings, Warnings
+          # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
           # @return [String]
-          attr_accessor :message
-          # Mutation code to indicate that Seam is in the process of updating the access times for this access method.
+          # Known values:
+          # - `code`
+          # - `card`
+          # - `mobile_key`
+          # - `cloud_key`
+          attr_accessor :access_method
+          # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
           # @return [String]
-          attr_accessor :mutation_code
-          # Date and time at which the mutation was created.
+          attr_accessor :acs_credential_id
+          # ID of the credential pool to which the credential belongs.
+          # @return [String, nil]
+          attr_accessor :acs_credential_pool_id
+          # ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [String]
+          attr_accessor :acs_system_id
+          # ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+          # @return [String, nil]
+          attr_accessor :acs_user_id
+          # Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [String, nil]
+          attr_accessor :card_number
+          # Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [String, nil]
+          attr_accessor :code
+          # ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+          # @return [String]
+          attr_accessor :connected_account_id
+          # Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+          # @return [String]
+          attr_accessor :display_name
+          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+          # @return [String, nil]
+          attr_accessor :ends_at
+          # Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+          # @return [String, nil]
+          # Known values:
+          # - `pti_card`
+          # - `brivo_credential`
+          # - `hid_credential`
+          # - `visionline_card`
+          # - `salto_ks_credential`
+          # - `assa_abloy_vostio_key`
+          # - `salto_space_key`
+          # - `latch_access`
+          # - `dormakaba_ambiance_credential`
+          # - `hotek_card`
+          # - `salto_ks_tag`
+          # - `avigilon_alta_credential`
+          # - `kisi_credential`
+          # - `akiles_credential`
+          attr_accessor :external_type
+          # Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+          # @return [String, nil]
+          attr_accessor :external_type_display_name
+          # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+          # @return [Boolean, nil]
+          attr_accessor :is_issued
+          # Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+          # @return [Boolean, nil]
+          attr_accessor :is_latest_desired_state_synced_with_provider
+          # Indicates whether Seam manages the credential.
+          # @return [TrueClass]
+          attr_accessor :is_managed
+          # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+          # @return [Boolean, nil]
+          attr_accessor :is_multi_phone_sync_credential
+          # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+          # @return [Boolean, nil]
+          attr_accessor :is_one_time_use
+          # ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [String, nil]
+          attr_accessor :parent_acs_credential_id
+          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+          # @return [String, nil]
+          attr_accessor :starts_at
+          # ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+          # @return [String, nil]
+          attr_accessor :user_identity_id
+          # ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+          # @return [String]
+          attr_accessor :workspace_id
+          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
           # @return [Time]
           date_accessor :created_at
+          # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+          # @return [Time, nil]
+          date_accessor :issued_at
+          # Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+          # @return [Time, nil]
+          date_accessor :latest_desired_state_synced_with_provider_at
         end
 
-        class VisionlineMetadata < BaseResource
-          # Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
-          # @return [Boolean, nil]
-          attr_accessor :auto_join
-          # Card function type in the Visionline access system.
-          # @return [String, nil]
-          attr_accessor :card_function_type
-          # ID of the card in the Visionline access system.
-          # @return [String, nil]
-          attr_accessor :card_id
-          # Common entrance IDs in the Visionline access system.
-          # @return [Array<String>]
-          attr_accessor :common_acs_entrance_ids
-          # ID of the credential in the Visionline access system.
-          # @return [String, nil]
-          attr_accessor :credential_id
-          # Guest entrance IDs in the Visionline access system.
-          # @return [Array<String>]
-          attr_accessor :guest_acs_entrance_ids
-          # Indicates whether the credential is valid.
-          # @return [Boolean, nil]
-          attr_accessor :is_valid
-          # IDs of the credentials to which you want to join.
-          # @return [Array<String>]
-          attr_accessor :joiner_acs_credential_ids
-        end
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of a scan to assign attempt. If the attempt was successful, includes the credential data that was scanned and assigned.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of scanning a physical card and assigning the credential to an ACS user.
+        # @return [String]
+        # Known values:
+        # - `SCAN_TO_ASSIGN_CREDENTIAL`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
 
-        class Warnings < BaseResource
-          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      # Assigning a credential to an access method is pending.
+      class AssignCredential < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
           attr_accessor :message
-          # The PIN code that was assigned instead.
-          # @return [String, nil]
-          attr_accessor :new_code
-          # ID of the original access method from which this backup access method was split, if applicable.
-          # @return [String, nil]
-          attr_accessor :original_access_method_id
-          # The originally requested PIN code that could not be used.
-          # @return [String, nil]
-          attr_accessor :original_code
+          # Error type to indicate that no matching credential was found.
           # @return [String]
-          attr_accessor :warning_code
-          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
-          # @return [String]
-          attr_accessor :warning_message
-          # Date and time at which Seam created the warning.
-          # @return [Time]
-          date_accessor :created_at
+          # Known values:
+          # - `uncategorized_error`
+          # - `action_attempt_expired`
+          # - `credential_not_found`
+          attr_accessor :type
         end
 
-        # Snapshot of credential data read from the physical encoder.
-        # @return [AcsCredentialOnEncoder, nil]
-        resource_accessor :acs_credential_on_encoder, AcsCredentialOnEncoder
-        # Corresponding credential data as stored on Seam and the access system.
-        # @return [AcsCredentialOnSeam, nil]
-        resource_accessor :acs_credential_on_seam, AcsCredentialOnSeam
-        # Akiles-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-        # @return [AkilesMetadata, nil]
-        resource_accessor :akiles_metadata, AkilesMetadata
-        # Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-        # @return [AssaAbloyVostioMetadata, nil]
-        resource_accessor :assa_abloy_vostio_metadata, AssaAbloyVostioMetadata
-        # Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-        # @return [VisionlineMetadata, nil]
-        resource_accessor :visionline_metadata, VisionlineMetadata
-        # @return [Array<Errors>]
-        resource_list_accessor :errors, Errors
-        # Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
-        # @return [Array<PendingMutations>]
-        resource_list_accessor :pending_mutations, PendingMutations
-        # @return [Array<Warnings>]
-        resource_list_accessor :warnings, Warnings
-        # @return [Hash, nil]
-        attr_accessor :access_code
-        # Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        class Result < BaseResource
+          class Errors < BaseResource
+            # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+            # @return [String]
+            # Known values:
+            # - `failed_to_issue`
+            attr_accessor :error_code
+            # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            # @return [String]
+            attr_accessor :message
+            # Date and time at which Seam created the error.
+            # @return [Time]
+            date_accessor :created_at
+          end
+
+          class PendingMutations < BaseResource
+            class From < BaseResource
+              # Previous end time for access.
+              # @return [Time, nil]
+              date_accessor :ends_at
+              # Previous start time for access.
+              # @return [Time, nil]
+              date_accessor :starts_at
+            end
+
+            class To < BaseResource
+              # New end time for access.
+              # @return [Time, nil]
+              date_accessor :ends_at
+              # New start time for access.
+              # @return [Time, nil]
+              date_accessor :starts_at
+            end
+
+            # Previous access time configuration.
+            # @return [From]
+            resource_accessor :from, From
+            # New access time configuration.
+            # @return [To]
+            resource_accessor :to, To
+            # Detailed description of the mutation.
+            # @return [String]
+            attr_accessor :message
+            # Mutation code to indicate that Seam is in the process of updating the access times for this access method.
+            # @return [String]
+            # Known values:
+            # - `provisioning_access`
+            # - `revoking_access`
+            # - `updating_access_times`
+            attr_accessor :mutation_code
+            # Date and time at which the mutation was created.
+            # @return [Time]
+            date_accessor :created_at
+          end
+
+          class Warnings < BaseResource
+            # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            # @return [String]
+            attr_accessor :message
+            # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+            # @return [String]
+            # Known values:
+            # - `being_deleted`
+            # - `updating_access_times`
+            # - `pulled_backup_access_code`
+            # - `delay_in_issuing`
+            attr_accessor :warning_code
+            # ID of the original access method from which this backup access method was split, if applicable.
+            # @return [String, nil]
+            attr_accessor :original_access_method_id
+            # Date and time at which Seam created the warning.
+            # @return [Time]
+            date_accessor :created_at
+          end
+
+          # Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+          # @return [Array<Errors>]
+          resource_list_accessor :errors, Errors
+          # Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+          # @return [Array<PendingMutations>]
+          resource_list_accessor :pending_mutations, PendingMutations
+          # Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+          # @return [Array<Warnings>]
+          resource_list_accessor :warnings, Warnings
+          # ID of the access method.
+          # @return [String]
+          attr_accessor :access_method_id
+          # Token of the client session associated with the access method.
+          # @return [String, nil]
+          attr_accessor :client_session_token
+          # The actual PIN code for code access methods.
+          # @return [String, nil]
+          attr_accessor :code
+          # ID of the customization profile associated with the access method.
+          # @return [String, nil]
+          attr_accessor :customization_profile_id
+          # Display name of the access method.
+          # @return [String]
+          attr_accessor :display_name
+          # URL of the Instant Key for mobile key access methods.
+          # @return [String, nil]
+          attr_accessor :instant_key_url
+          # Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+          # @return [Boolean, nil]
+          attr_accessor :is_assignment_required
+          # Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+          # @return [Boolean, nil]
+          attr_accessor :is_encoding_required
+          # Indicates whether the access method has been issued.
+          # @return [Boolean]
+          attr_accessor :is_issued
+          # Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+          # @return [Boolean, nil]
+          attr_accessor :is_ready_for_assignment
+          # Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+          # @return [Boolean, nil]
+          attr_accessor :is_ready_for_encoding
+          # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+          # @return [String]
+          # Known values:
+          # - `code`
+          # - `card`
+          # - `mobile_key`
+          # - `cloud_key`
+          attr_accessor :mode
+          # ID of the Seam workspace associated with the access method.
+          # @return [String]
+          attr_accessor :workspace_id
+          # Date and time at which the access method was created.
+          # @return [Time]
+          date_accessor :created_at
+          # Date and time at which the access method was issued.
+          # @return [Time, nil]
+          date_accessor :issued_at
+        end
+
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of assigning a credential. If successful, includes the updated access method with the assigned credential.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
         # @return [String]
-        attr_accessor :access_method
-        # ID of the access method.
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of assigning a pre-registered card credential to an access method.
         # @return [String]
-        attr_accessor :access_method_id
-        # ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        # Known values:
+        # - `ASSIGN_CREDENTIAL`
+        attr_accessor :action_type
         # @return [String]
-        attr_accessor :acs_credential_id
-        # ID of the credential pool to which the credential belongs.
-        # @return [String, nil]
-        attr_accessor :acs_credential_pool_id
-        # ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Resetting a sandbox workspace is pending.
+      class ResetSandboxWorkspace < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
         # @return [String]
-        attr_accessor :acs_system_id
-        # ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
-        # @return [String, nil]
-        attr_accessor :acs_user_id
-        # Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-        # @return [String, nil]
-        attr_accessor :card_number
-        # Token of the client session associated with the access method.
-        # @return [String, nil]
-        attr_accessor :client_session_token
-        # @return [String, nil]
-        attr_accessor :code
-        # ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of resetting a sandbox workspace.
         # @return [String]
-        attr_accessor :connected_account_id
-        # ID of the customization profile associated with the access method.
-        # @return [String, nil]
-        attr_accessor :customization_profile_id
+        # Known values:
+        # - `RESET_SANDBOX_WORKSPACE`
+        attr_accessor :action_type
         # @return [String]
-        attr_accessor :display_name
-        # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
-        # @return [String, nil]
-        attr_accessor :ends_at
-        # Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
-        # @return [String, nil]
-        attr_accessor :external_type
-        # Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
-        # @return [String, nil]
-        attr_accessor :external_type_display_name
-        # URL of the Instant Key for mobile key access methods.
-        # @return [String, nil]
-        attr_accessor :instant_key_url
-        # Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
-        # @return [Boolean, nil]
-        attr_accessor :is_assignment_required
-        # Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
-        # @return [Boolean, nil]
-        attr_accessor :is_encoding_required
-        # @return [Boolean, nil]
-        attr_accessor :is_issued
-        # Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
-        # @return [Boolean, nil]
-        attr_accessor :is_latest_desired_state_synced_with_provider
-        # Indicates whether Seam manages the credential.
-        # @return [Boolean]
-        attr_accessor :is_managed
-        # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
-        # @return [Boolean, nil]
-        attr_accessor :is_multi_phone_sync_credential
-        # Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
-        # @return [Boolean, nil]
-        attr_accessor :is_one_time_use
-        # Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
-        # @return [Boolean, nil]
-        attr_accessor :is_ready_for_assignment
-        # Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
-        # @return [Boolean, nil]
-        attr_accessor :is_ready_for_encoding
-        # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Setting the fan mode is pending.
+      class SetFanMode < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
         # @return [String]
-        attr_accessor :mode
-        # @return [Hash]
-        attr_accessor :noise_threshold
-        # ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
-        # @return [String, nil]
-        attr_accessor :parent_acs_credential_id
-        # Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-        # @return [String, nil]
-        attr_accessor :starts_at
-        # ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
-        # @return [String, nil]
-        attr_accessor :user_identity_id
-        # @return [Boolean, nil]
-        attr_accessor :was_confirmed_by_device
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of setting the fan mode on a thermostat.
         # @return [String]
-        attr_accessor :workspace_id
-        # @return [Time]
-        date_accessor :created_at
-        # @return [Time, nil]
-        date_accessor :issued_at
-        # Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
-        # @return [Time, nil]
-        date_accessor :latest_desired_state_synced_with_provider_at
+        # Known values:
+        # - `SET_FAN_MODE`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Setting the HVAC mode is pending.
+      class SetHvacMode < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of setting the HVAC mode on a thermostat.
+        # @return [String]
+        # Known values:
+        # - `SET_HVAC_MODE`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Activating a climate preset is pending.
+      class ActivateClimatePreset < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of a climate preset activation.
+        # @return [String]
+        # Known values:
+        # - `ACTIVATE_CLIMATE_PRESET`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Simulating a keypad code entry is pending.
+      class SimulateKeypadCodeEntry < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of simulating a keypad code entry.
+        # @return [String]
+        # Known values:
+        # - `SIMULATE_KEYPAD_CODE_ENTRY`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Simulating a manual lock action using a keypad is pending.
+      class SimulateManualLockViaKeypad < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of simulating a manual lock action using a keypad.
+        # @return [String]
+        # Known values:
+        # - `SIMULATE_MANUAL_LOCK_VIA_KEYPAD`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Pushing thermostat weekly programs is pending.
+      class PushThermostatPrograms < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of pushing thermostat programs.
+        # @return [String]
+        # Known values:
+        # - `PUSH_THERMOSTAT_PROGRAMS`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      # Configuring the auto-lock is pending.
+      class ConfigureAutoLock < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Action attempt to track the status of configuring the auto-lock on a lock.
+        # @return [String]
+        # Known values:
+        # - `CONFIGURE_AUTO_LOCK`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class SyncAccessCodes < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Syncing access codes is pending.
+        # @return [String]
+        # Known values:
+        # - `SYNC_ACCESS_CODES`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class CreateAccessCode < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          # Created access code.
+          # @return [Hash]
+          attr_accessor :access_code
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Creating an access code is pending.
+        # @return [String]
+        # Known values:
+        # - `CREATE_ACCESS_CODE`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class DeleteAccessCode < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Deleting an access code is pending.
+        # @return [String]
+        # Known values:
+        # - `DELETE_ACCESS_CODE`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class UpdateAccessCode < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          # Updated access code.
+          # @return [Hash, nil]
+          attr_accessor :access_code
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Updating an access code is pending.
+        # @return [String]
+        # Known values:
+        # - `UPDATE_ACCESS_CODE`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class CreateNoiseThreshold < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          # Created noise threshold.
+          # @return [Hash]
+          attr_accessor :noise_threshold
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Creating a noise threshold is pending.
+        # @return [String]
+        # Known values:
+        # - `CREATE_NOISE_THRESHOLD`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class DeleteNoiseThreshold < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Deleting a noise threshold is pending.
+        # @return [String]
+        # Known values:
+        # - `DELETE_NOISE_THRESHOLD`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
+      end
+
+      class UpdateNoiseThreshold < ActionAttempt
+        class Error < BaseResource
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Type of the error.
+          # @return [String]
+          attr_accessor :type
+        end
+
+        class Result < BaseResource
+          # Updated noise threshold.
+          # @return [Hash]
+          attr_accessor :noise_threshold
+        end
+
+        # Error associated with the action.
+        # @return [Error, nil]
+        resource_accessor :error, Error
+        # Result of the action.
+        # @return [Result, nil]
+        resource_accessor :result, Result
+        # ID of the action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Updating a noise threshold is pending.
+        # @return [String]
+        # Known values:
+        # - `UPDATE_NOISE_THRESHOLD`
+        attr_accessor :action_type
+        # @return [String]
+        # Known values:
+        # - `success`
+        # - `pending`
+        # - `error`
+        attr_accessor :status
       end
 
       # Error associated with the action.
-      # @return [Error]
+      # @return [Error, nil]
       resource_accessor :error, Error
-      # @return [Result]
+      # @return [Result, nil]
       resource_accessor :result, Result
       # ID of the action attempt.
       # @return [String]
       attr_accessor :action_attempt_id
       # @return [String]
+      # Known values:
+      # - `LOCK_DOOR`
+      # - `UNLOCK_DOOR`
+      # - `SCAN_CREDENTIAL`
+      # - `ENCODE_CREDENTIAL`
+      # - `SCAN_TO_ASSIGN_CREDENTIAL`
+      # - `ASSIGN_CREDENTIAL`
+      # - `RESET_SANDBOX_WORKSPACE`
+      # - `SET_FAN_MODE`
+      # - `SET_HVAC_MODE`
+      # - `ACTIVATE_CLIMATE_PRESET`
+      # - `SIMULATE_KEYPAD_CODE_ENTRY`
+      # - `SIMULATE_MANUAL_LOCK_VIA_KEYPAD`
+      # - `PUSH_THERMOSTAT_PROGRAMS`
+      # - `CONFIGURE_AUTO_LOCK`
+      # - `SYNC_ACCESS_CODES`
+      # - `CREATE_ACCESS_CODE`
+      # - `DELETE_ACCESS_CODE`
+      # - `UPDATE_ACCESS_CODE`
+      # - `CREATE_NOISE_THRESHOLD`
+      # - `DELETE_NOISE_THRESHOLD`
+      # - `UPDATE_NOISE_THRESHOLD`
       attr_accessor :action_type
       # @return [String]
+      # Known values:
+      # - `success`
+      # - `pending`
+      # - `error`
       attr_accessor :status
+
+      discriminated_by :action_type, {
+        "LOCK_DOOR" => LockDoor,
+        "UNLOCK_DOOR" => UnlockDoor,
+        "SCAN_CREDENTIAL" => ScanCredential,
+        "ENCODE_CREDENTIAL" => EncodeCredential,
+        "SCAN_TO_ASSIGN_CREDENTIAL" => ScanToAssignCredential,
+        "ASSIGN_CREDENTIAL" => AssignCredential,
+        "RESET_SANDBOX_WORKSPACE" => ResetSandboxWorkspace,
+        "SET_FAN_MODE" => SetFanMode,
+        "SET_HVAC_MODE" => SetHvacMode,
+        "ACTIVATE_CLIMATE_PRESET" => ActivateClimatePreset,
+        "SIMULATE_KEYPAD_CODE_ENTRY" => SimulateKeypadCodeEntry,
+        "SIMULATE_MANUAL_LOCK_VIA_KEYPAD" => SimulateManualLockViaKeypad,
+        "PUSH_THERMOSTAT_PROGRAMS" => PushThermostatPrograms,
+        "CONFIGURE_AUTO_LOCK" => ConfigureAutoLock,
+        "SYNC_ACCESS_CODES" => SyncAccessCodes,
+        "CREATE_ACCESS_CODE" => CreateAccessCode,
+        "DELETE_ACCESS_CODE" => DeleteAccessCode,
+        "UPDATE_ACCESS_CODE" => UpdateAccessCode,
+        "CREATE_NOISE_THRESHOLD" => CreateNoiseThreshold,
+        "DELETE_NOISE_THRESHOLD" => DeleteNoiseThreshold,
+        "UPDATE_NOISE_THRESHOLD" => UpdateNoiseThreshold
+      }.freeze
     end
   end
 end

--- a/lib/seam/resources/connect_webview.rb
+++ b/lib/seam/resources/connect_webview.rb
@@ -16,6 +16,12 @@ module Seam
     class ConnectWebview < BaseResource
       # High-level device capabilities that the Connect Webview can accept. When creating a Connect Webview, you can specify the types of devices that it can connect to Seam. If you do not set custom `accepted_capabilities`, Seam uses a default set of `accepted_capabilities` for each provider. For example, if you create a Connect Webview that accepts SmartThing devices, without specifying `accepted_capabilities`, Seam accepts only SmartThings locks. To connect SmartThings thermostats and locks to Seam, create a Connect Webview and include both `thermostat` and `lock` in the `accepted_capabilities`.
       # @return [Array<String>]
+      # Known values:
+      # - `lock`
+      # - `thermostat`
+      # - `noise_sensor`
+      # - `access_control`
+      # - `camera`
       attr_accessor :accepted_capabilities
       # List of accepted [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
       # @return [Array<String>]
@@ -46,6 +52,10 @@ module Seam
       attr_accessor :customer_key
       # Device selection mode of the Connect Webview. Supported values: `none`, `single`, `multiple`.
       # @return [String]
+      # Known values:
+      # - `none`
+      # - `single`
+      # - `multiple`
       attr_accessor :device_selection_mode
       # Indicates whether the user logged in successfully using the Connect Webview.
       # @return [Boolean]
@@ -55,6 +65,10 @@ module Seam
       attr_accessor :selected_provider
       # Status of the Connect Webview. `authorized` indicates that the user has successfully logged into their device or system account, thereby completing the Connect Webview.
       # @return [String]
+      # Known values:
+      # - `pending`
+      # - `failed`
+      # - `authorized`
       attr_accessor :status
       # URL for the Connect Webview. You use the URL to display the Connect Webview flow to your user.
       # @return [String]

--- a/lib/seam/resources/connected_account.rb
+++ b/lib/seam/resources/connected_account.rb
@@ -4,33 +4,123 @@ module Seam
   module Resources
     # Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
     class ConnectedAccount < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
-        class SaltoKsMetadata < BaseResource
-          class Sites < BaseResource
-            # ID of a Salto site associated with the connected account that has an error.
-            # @return [String, nil]
-            attr_accessor :site_id
-            # Name of a Salto site associated with the connected account that has an error.
-            # @return [String, nil]
-            attr_accessor :site_name
-            # Subscription limit of site users for a Salto site associated with the connected account that has an error.
-            # @return [Integer, nil]
-            attr_accessor :site_user_subscription_limit
-            # Count of subscribed site users for a Salto site associated with the connected account that has an error.
-            # @return [Integer, nil]
-            attr_accessor :subscribed_site_user_count
-          end
-
-          # Salto sites associated with the connected account that has an error.
-          # @return [Array<Sites>]
-          resource_list_accessor :sites, Sites
+        # Indicates that the account is disconnected.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
         end
 
-        # Salto KS metadata associated with the connected account that has an error.
-        # @return [SaltoKsMetadata]
-        resource_accessor :salto_ks_metadata, SaltoKsMetadata
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the maximum number of users allowed for the site has been reached. This means that new access codes cannot be created. Contact Salto support to increase the user limit.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          class SaltoKsMetadata < BaseResource
+            class Sites < BaseResource
+              # ID of a Salto site associated with the connected account that has an error.
+              # @return [String, nil]
+              attr_accessor :site_id
+              # Name of a Salto site associated with the connected account that has an error.
+              # @return [String, nil]
+              attr_accessor :site_name
+              # Subscription limit of site users for a Salto site associated with the connected account that has an error.
+              # @return [Integer, nil]
+              attr_accessor :site_user_subscription_limit
+              # Count of subscribed site users for a Salto site associated with the connected account that has an error.
+              # @return [Integer, nil]
+              attr_accessor :subscribed_site_user_count
+            end
+
+            # Salto sites associated with the connected account that has an error.
+            # @return [Array<Sites>]
+            resource_list_accessor :sites, Sites
+          end
+
+          # Salto KS metadata associated with the connected account that has an error.
+          # @return [SaltoKsMetadata]
+          resource_accessor :salto_ks_metadata, SaltoKsMetadata
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account could not be connected. Contact dormakaba support.
+        class DormakabaSitesDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `account_disconnected`
+        # - `bridge_disconnected`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `dormakaba_sites_disconnected`
         attr_accessor :error_code
         # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
         # @return [Boolean, nil]
@@ -44,6 +134,13 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "account_disconnected" => AccountDisconnected,
+          "bridge_disconnected" => BridgeDisconnected,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "dormakaba_sites_disconnected" => DormakabaSitesDisconnected
+        }.freeze
       end
 
       class UserIdentifier < BaseResource
@@ -64,40 +161,181 @@ module Seam
         attr_accessor :username
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        class SaltoKsMetadata < BaseResource
-          class Sites < BaseResource
-            # ID of a Salto site associated with the connected account that has a warning.
-            # @return [String, nil]
-            attr_accessor :site_id
-            # Name of a Salto site associated with the connected account that has a warning.
-            # @return [String, nil]
-            attr_accessor :site_name
-            # Subscription limit of site users for a Salto site associated with the connected account that has a warning.
-            # @return [Integer, nil]
-            attr_accessor :site_user_subscription_limit
-            # Count of subscribed site users for a Salto site associated with the connected account that has a warning.
-            # @return [Integer, nil]
-            attr_accessor :subscribed_site_user_count
-          end
-
-          # Salto sites associated with the connected account that has a warning.
-          # @return [Array<Sites>]
-          resource_list_accessor :sites, Sites
+        # Indicates that scheduled downtime is planned for the connected account.
+        class ScheduledMaintenanceWindow < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `scheduled_maintenance_window`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
         end
 
-        # Salto KS metadata associated with the connected account that has a warning.
-        # @return [SaltoKsMetadata]
-        resource_accessor :salto_ks_metadata, SaltoKsMetadata
+        # Indicates that an unknown issue occurred while syncing the state of the connected account with the provider. This issue may affect the proper functioning of one or more resources in the account.
+        class UnknownIssueWithConnectedAccount < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_connected_account`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS site has exceeded 80% of the maximum number of allowed users. Increase your subscription limit or delete some users from your site.
+        class SaltoKsSubscriptionLimitAlmostReached < Warnings
+          class SaltoKsMetadata < BaseResource
+            class Sites < BaseResource
+              # ID of a Salto site associated with the connected account that has a warning.
+              # @return [String, nil]
+              attr_accessor :site_id
+              # Name of a Salto site associated with the connected account that has a warning.
+              # @return [String, nil]
+              attr_accessor :site_name
+              # Subscription limit of site users for a Salto site associated with the connected account that has a warning.
+              # @return [Integer, nil]
+              attr_accessor :site_user_subscription_limit
+              # Count of subscribed site users for a Salto site associated with the connected account that has a warning.
+              # @return [Integer, nil]
+              attr_accessor :subscribed_site_user_count
+            end
+
+            # Salto sites associated with the connected account that has a warning.
+            # @return [Array<Sites>]
+            resource_list_accessor :sites, Sites
+          end
+
+          # Salto KS metadata associated with the connected account that has a warning.
+          # @return [SaltoKsMetadata]
+          resource_accessor :salto_ks_metadata, SaltoKsMetadata
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_almost_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Connected Account requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.
+        class AccountReauthorizationRequested < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_reauthorization_requested`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the connected account is currently being deleted. All devices, access codes, and other resources associated with this account are in the process of being removed from Seam.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the connected account's provider service is temporarily unavailable. Seam will automatically retry and reconnect when the service becomes available again.
+        class ProviderServiceUnavailable < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `provider_service_unavailable`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the connected account requires additional setup before it can be fully operational. Follow the instructions in the warning message to complete the setup.
+        class SetupRequired < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `setup_required`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account are not approved. Contact support@getseam.com to finish setting up your account.
+        class DormakabaSitesUnapproved < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_unapproved`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `scheduled_maintenance_window`
+        # - `unknown_issue_with_connected_account`
+        # - `salto_ks_subscription_limit_almost_reached`
+        # - `account_reauthorization_requested`
+        # - `being_deleted`
+        # - `provider_service_unavailable`
+        # - `setup_required`
+        # - `dormakaba_sites_unapproved`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "scheduled_maintenance_window" => ScheduledMaintenanceWindow,
+          "unknown_issue_with_connected_account" => UnknownIssueWithConnectedAccount,
+          "salto_ks_subscription_limit_almost_reached" => SaltoKsSubscriptionLimitAlmostReached,
+          "account_reauthorization_requested" => AccountReauthorizationRequested,
+          "being_deleted" => BeingDeleted,
+          "provider_service_unavailable" => ProviderServiceUnavailable,
+          "setup_required" => SetupRequired,
+          "dormakaba_sites_unapproved" => DormakabaSitesUnapproved
+        }.freeze
       end
 
       # User identifier associated with the connected account.
@@ -111,6 +349,12 @@ module Seam
       resource_list_accessor :warnings, Warnings
       # List of capabilities that were accepted during the account connection process.
       # @return [Array<String>]
+      # Known values:
+      # - `lock`
+      # - `thermostat`
+      # - `noise_sensor`
+      # - `access_control`
+      # - `camera`
       attr_accessor :accepted_capabilities
       # Type of connected account.
       # @return [String, nil]

--- a/lib/seam/resources/device.rb
+++ b/lib/seam/resources/device.rb
@@ -31,23 +31,316 @@ module Seam
         attr_accessor :provider_category
       end
 
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that the account is disconnected.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto site user limit has been reached.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam's integration user does not have sufficient permissions on the provider's system to which this device belongs, so Seam cannot manage access codes or unlock the device. See the error message for specifics, then either reauthorize the connected account in Seam or grant the integration user the required permissions in the provider's system.
+        class InsufficientPermissions < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `insufficient_permissions`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account could not be connected. Contact dormakaba support.
+        class DormakabaSitesDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is offline.
+        class DeviceOffline < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_offline`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has been removed.
+        class DeviceRemoved < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_removed`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the hub is disconnected.
+        class HubDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is disconnected.
+        class DeviceDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is empty.
+        class EmptyBackupAccessCodePool < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `empty_backup_access_code_pool`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the user is not authorized to use the August lock.
+        class AugustLockNotAuthorized < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `august_lock_not_authorized`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that device credentials are missing.
+        class MissingDeviceCredentials < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `missing_device_credentials`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the auxiliary heat is running.
+        class AuxiliaryHeatRunning < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `auxiliary_heat_running`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a subscription is required to connect.
+        class SubscriptionRequired < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `subscription_required`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `account_disconnected`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `insufficient_permissions`
+        # - `dormakaba_sites_disconnected`
+        # - `device_offline`
+        # - `device_removed`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        # - `empty_backup_access_code_pool`
+        # - `august_lock_not_authorized`
+        # - `missing_device_credentials`
+        # - `auxiliary_heat_running`
+        # - `subscription_required`
+        # - `bridge_disconnected`
         attr_accessor :error_code
-        # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
-        # @return [Boolean, nil]
-        attr_accessor :is_bridge_error
-        # @return [Boolean, nil]
-        attr_accessor :is_connected_account_error
-        # @return [Boolean]
-        attr_accessor :is_device_error
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "account_disconnected" => AccountDisconnected,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "insufficient_permissions" => InsufficientPermissions,
+          "dormakaba_sites_disconnected" => DormakabaSitesDisconnected,
+          "device_offline" => DeviceOffline,
+          "device_removed" => DeviceRemoved,
+          "hub_disconnected" => HubDisconnected,
+          "device_disconnected" => DeviceDisconnected,
+          "empty_backup_access_code_pool" => EmptyBackupAccessCodePool,
+          "august_lock_not_authorized" => AugustLockNotAuthorized,
+          "missing_device_credentials" => MissingDeviceCredentials,
+          "auxiliary_heat_running" => AuxiliaryHeatRunning,
+          "subscription_required" => SubscriptionRequired,
+          "bridge_disconnected" => BridgeDisconnected
+        }.freeze
       end
 
       class Location < BaseResource
@@ -93,6 +386,11 @@ module Seam
           attr_accessor :level
           # Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
           # @return [String]
+          # Known values:
+          # - `critical`
+          # - `low`
+          # - `good`
+          # - `full`
           attr_accessor :status
         end
 
@@ -625,6 +923,9 @@ module Seam
           attr_accessor :device_id
           # Device model for a NoiseAware device.
           # @return [String, nil]
+          # Known values:
+          # - `indoor`
+          # - `outdoor`
           attr_accessor :device_model
           # Device name for a NoiseAware device.
           # @return [String, nil]
@@ -766,6 +1067,9 @@ module Seam
           attr_accessor :name
           # Unlock method for Seam Bridge.
           # @return [String, nil]
+          # Known values:
+          # - `bridge`
+          # - `doorking`
           attr_accessor :unlock_method
         end
 
@@ -966,6 +1270,21 @@ module Seam
 
         class CodeConstraints < BaseResource
           # @return [String]
+          # Known values:
+          # - `no_zeros`
+          # - `cannot_start_with_12`
+          # - `no_triple_consecutive_ints`
+          # - `cannot_specify_pin_code`
+          # - `pin_code_matches_existing_set`
+          # - `start_date_in_future`
+          # - `no_ascending_or_descending_sequence`
+          # - `at_least_three_unique_digits`
+          # - `cannot_contain_089`
+          # - `cannot_contain_0789`
+          # - `unique_first_four_digits`
+          # - `no_all_same_digits`
+          # - `name_length`
+          # - `name_must_be_unique`
           attr_accessor :constraint_type
           # Maximum name length constraint for access codes.
           # @return [Float, nil]
@@ -1117,6 +1436,9 @@ module Seam
             attr_accessor :is_optimized
             # Indicates whether the climate preset is owned by the user or the system.
             # @return [String, nil]
+            # Known values:
+            # - `user`
+            # - `system`
             attr_accessor :owner
           end
 
@@ -1137,6 +1459,13 @@ module Seam
           attr_accessor :climate_preset_key
           # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
           # @return [String, nil]
+          # Known values:
+          # - `home`
+          # - `away`
+          # - `wake`
+          # - `sleep`
+          # - `occupied`
+          # - `unoccupied`
           attr_accessor :climate_preset_mode
           # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1149,6 +1478,10 @@ module Seam
           attr_accessor :display_name
           # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
           # @return [String, nil]
+          # Known values:
+          # - `auto`
+          # - `on`
+          # - `circulate`
           attr_accessor :fan_mode_setting
           # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1158,6 +1491,12 @@ module Seam
           attr_accessor :heating_set_point_fahrenheit
           # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
           # @return [String, nil]
+          # Known values:
+          # - `off`
+          # - `heat`
+          # - `cool`
+          # - `heat_cool`
+          # - `eco`
           attr_accessor :hvac_mode_setting
           # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
           # @return [Boolean]
@@ -1178,6 +1517,9 @@ module Seam
             attr_accessor :is_optimized
             # Indicates whether the climate preset is owned by the user or the system.
             # @return [String, nil]
+            # Known values:
+            # - `user`
+            # - `system`
             attr_accessor :owner
           end
 
@@ -1198,6 +1540,13 @@ module Seam
           attr_accessor :climate_preset_key
           # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
           # @return [String, nil]
+          # Known values:
+          # - `home`
+          # - `away`
+          # - `wake`
+          # - `sleep`
+          # - `occupied`
+          # - `unoccupied`
           attr_accessor :climate_preset_mode
           # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1210,6 +1559,10 @@ module Seam
           attr_accessor :display_name
           # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
           # @return [String, nil]
+          # Known values:
+          # - `auto`
+          # - `on`
+          # - `circulate`
           attr_accessor :fan_mode_setting
           # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1219,6 +1572,12 @@ module Seam
           attr_accessor :heating_set_point_fahrenheit
           # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
           # @return [String, nil]
+          # Known values:
+          # - `off`
+          # - `heat`
+          # - `cool`
+          # - `heat_cool`
+          # - `eco`
           attr_accessor :hvac_mode_setting
           # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
           # @return [Boolean, nil]
@@ -1239,6 +1598,9 @@ module Seam
             attr_accessor :is_optimized
             # Indicates whether the climate preset is owned by the user or the system.
             # @return [String, nil]
+            # Known values:
+            # - `user`
+            # - `system`
             attr_accessor :owner
           end
 
@@ -1259,6 +1621,13 @@ module Seam
           attr_accessor :climate_preset_key
           # The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
           # @return [String, nil]
+          # Known values:
+          # - `home`
+          # - `away`
+          # - `wake`
+          # - `sleep`
+          # - `occupied`
+          # - `unoccupied`
           attr_accessor :climate_preset_mode
           # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1271,6 +1640,10 @@ module Seam
           attr_accessor :display_name
           # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
           # @return [String, nil]
+          # Known values:
+          # - `auto`
+          # - `on`
+          # - `circulate`
           attr_accessor :fan_mode_setting
           # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
           # @return [Float, nil]
@@ -1280,6 +1653,12 @@ module Seam
           attr_accessor :heating_set_point_fahrenheit
           # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
           # @return [String, nil]
+          # Known values:
+          # - `off`
+          # - `heat`
+          # - `cool`
+          # - `heat_cool`
+          # - `eco`
           attr_accessor :hvac_mode_setting
           # Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
           # @return [Boolean, nil]
@@ -1606,17 +1985,38 @@ module Seam
         attr_accessor :active_thermostat_schedule_id
         # Climate preset modes that the thermostat supports, such as "home", "away", "wake", "sleep", "occupied", and "unoccupied".
         # @return [Array<String>]
+        # Known values:
+        # - `home`
+        # - `away`
+        # - `wake`
+        # - `sleep`
+        # - `occupied`
+        # - `unoccupied`
         attr_accessor :available_climate_preset_modes
         # Fan mode settings that the thermostat supports.
         # @return [Array<String>]
+        # Known values:
+        # - `auto`
+        # - `on`
+        # - `circulate`
         attr_accessor :available_fan_mode_settings
         # HVAC mode settings that the thermostat supports.
         # @return [Array<String>]
+        # Known values:
+        # - `off`
+        # - `heat`
+        # - `cool`
+        # - `heat_cool`
+        # - `eco`
         attr_accessor :available_hvac_mode_settings
         # Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
         # @return [String, nil]
         attr_accessor :fallback_climate_preset_key
         # @return [String, nil]
+        # Known values:
+        # - `auto`
+        # - `on`
+        # - `circulate`
         # @deprecated Use `current_climate_setting.fan_mode_setting` instead.
         attr_accessor :fan_mode_setting
         # Indicates whether the connected HVAC system is currently cooling, as reported by the thermostat.
@@ -1681,22 +2081,486 @@ module Seam
         attr_accessor :thermostat_daily_program_period_precision_minutes
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        # Number of active access codes on the device when the warning was set.
-        # @return [Integer]
-        attr_accessor :active_access_code_count
-        # Maximum number of active access codes supported by the device.
-        # @return [Integer]
-        attr_accessor :max_active_access_code_count
+        # Indicates that the backup access code is unhealthy.
+        class PartialBackupAccessCodePool < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `partial_backup_access_code_pool`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that there are too many backup codes.
+        class ManyActiveBackupCodes < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `many_active_backup_codes`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a third-party integration has been detected.
+        class ThirdPartyIntegrationDetected < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `third_party_integration_detected`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Remote Unlock feature is not enabled in the settings."
+        class TtlockLockGatewayUnlockingNotEnabled < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ttlock_lock_gateway_unlocking_not_enabled`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the gateway signal is weak.
+        class TtlockWeakGatewaySignal < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ttlock_weak_gateway_signal`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is in power saving mode and may have limited functionality.
+        class PowerSavingMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `power_saving_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the temperature threshold has been exceeded.
+        class TemperatureThresholdExceeded < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `temperature_threshold_exceeded`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device appears to be unresponsive.
+        class DeviceCommunicationDegraded < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_communication_degraded`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a scheduled maintenance window has been detected.
+        class ScheduledMaintenanceWindow < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `scheduled_maintenance_window`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has a flaky connection.
+        class DeviceHasFlakyConnection < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_has_flaky_connection`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS lock is in Office Mode. Access Codes will not unlock doors.
+        class SaltoKsOfficeMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_office_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS lock is in Privacy Mode. Access Codes will not unlock doors.
+        class SaltoKsPrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the lock is in Privacy Mode. Access codes and remote unlock are blocked until Privacy Mode is disabled.
+        class PrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS site has exceeded 80% of the maximum number of allowed users. Increase your subscription limit or delete some users from your site.
+        class SaltoKsSubscriptionLimitAlmostReached < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_almost_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a change in the reported device model has been detected for this Salto KS lock, which may occur after an IQ hub reset. Access code support may be affected. See https://help.getseam.com/articles/5098842588-salto-ks-lock-loses-access-code-support for troubleshooting steps.
+        class SaltoKsLockAccessCodeSupportRemoved < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_lock_access_code_support_removed`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that an unknown issue occurred while syncing the state of the phone with the provider. This issue may affect the proper functioning of the phone.
+        class UnknownIssueWithPhone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_phone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam detected that the Lockly device does not have a time zone configured. Time-bound codes may not work as expected.
+        class LocklyTimeZoneNotConfigured < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `lockly_time_zone_not_configured`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam does not know the time zone of the Ultraloq device. Set a time zone to enable time-bound access codes.
+        class UltraloqTimeZoneUnknown < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ultraloq_time_zone_unknown`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam does not know the device's time zone. Set a time zone to enable time-bound access codes.
+        class TimeZoneUnknown < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_zone_unknown`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device's configured time zone does not match its hardware UTC offset. Time-bound access codes may activate at the wrong local time.
+        class TimeZoneMismatch < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_zone_mismatch`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the 2N device does not have a time zone configured. Configure a time zone on the device to enable access codes.
+        class TwoNDeviceMissingTimezone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `two_n_device_missing_timezone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a hub or relay must be connected to unlock additional capabilities such as remote unlock.
+        class HubRequiredForAdditionalCapabilities < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_required_for_additional_capabilities`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates a provider-specific issue that may affect device functionality.
+        class ProviderIssue < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `provider_issue`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the key is in a locker that does not support the access codes API.
+        class KeynestUnsupportedLocker < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `keynest_unsupported_locker`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the accessory keypad exists, but is not linked to the Igloohome Bridge. Online access code programming will fail until the keypad is linked to the Igloohome Bridge in the Igloohome app.
+        class AccessoryKeypadSetupRequired < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `accessory_keypad_setup_required`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device may optimistically be reported as online because the provider does not reliably report its online status.
+        class UnreliableOnlineStatus < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unreliable_online_status`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has reached its maximum number of active access codes. Delete existing codes before creating new ones.
+        class MaxAccessCodesReached < Warnings
+          # Number of active access codes on the device when the warning was set.
+          # @return [Integer]
+          attr_accessor :active_access_code_count
+          # Maximum number of active access codes supported by the device.
+          # @return [Integer]
+          attr_accessor :max_active_access_code_count
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `max_access_codes_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `partial_backup_access_code_pool`
+        # - `many_active_backup_codes`
+        # - `third_party_integration_detected`
+        # - `ttlock_lock_gateway_unlocking_not_enabled`
+        # - `ttlock_weak_gateway_signal`
+        # - `power_saving_mode`
+        # - `temperature_threshold_exceeded`
+        # - `device_communication_degraded`
+        # - `scheduled_maintenance_window`
+        # - `device_has_flaky_connection`
+        # - `salto_ks_office_mode`
+        # - `salto_ks_privacy_mode`
+        # - `privacy_mode`
+        # - `salto_ks_subscription_limit_almost_reached`
+        # - `salto_ks_lock_access_code_support_removed`
+        # - `unknown_issue_with_phone`
+        # - `lockly_time_zone_not_configured`
+        # - `ultraloq_time_zone_unknown`
+        # - `time_zone_unknown`
+        # - `time_zone_mismatch`
+        # - `two_n_device_missing_timezone`
+        # - `hub_required_for_additional_capabilities`
+        # - `provider_issue`
+        # - `keynest_unsupported_locker`
+        # - `accessory_keypad_setup_required`
+        # - `unreliable_online_status`
+        # - `max_access_codes_reached`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "partial_backup_access_code_pool" => PartialBackupAccessCodePool,
+          "many_active_backup_codes" => ManyActiveBackupCodes,
+          "third_party_integration_detected" => ThirdPartyIntegrationDetected,
+          "ttlock_lock_gateway_unlocking_not_enabled" => TtlockLockGatewayUnlockingNotEnabled,
+          "ttlock_weak_gateway_signal" => TtlockWeakGatewaySignal,
+          "power_saving_mode" => PowerSavingMode,
+          "temperature_threshold_exceeded" => TemperatureThresholdExceeded,
+          "device_communication_degraded" => DeviceCommunicationDegraded,
+          "scheduled_maintenance_window" => ScheduledMaintenanceWindow,
+          "device_has_flaky_connection" => DeviceHasFlakyConnection,
+          "salto_ks_office_mode" => SaltoKsOfficeMode,
+          "salto_ks_privacy_mode" => SaltoKsPrivacyMode,
+          "privacy_mode" => PrivacyMode,
+          "salto_ks_subscription_limit_almost_reached" => SaltoKsSubscriptionLimitAlmostReached,
+          "salto_ks_lock_access_code_support_removed" => SaltoKsLockAccessCodeSupportRemoved,
+          "unknown_issue_with_phone" => UnknownIssueWithPhone,
+          "lockly_time_zone_not_configured" => LocklyTimeZoneNotConfigured,
+          "ultraloq_time_zone_unknown" => UltraloqTimeZoneUnknown,
+          "time_zone_unknown" => TimeZoneUnknown,
+          "time_zone_mismatch" => TimeZoneMismatch,
+          "two_n_device_missing_timezone" => TwoNDeviceMissingTimezone,
+          "hub_required_for_additional_capabilities" => HubRequiredForAdditionalCapabilities,
+          "provider_issue" => ProviderIssue,
+          "keynest_unsupported_locker" => KeynestUnsupportedLocker,
+          "accessory_keypad_setup_required" => AccessoryKeypadSetupRequired,
+          "unreliable_online_status" => UnreliableOnlineStatus,
+          "max_access_codes_reached" => MaxAccessCodesReached
+        }.freeze
       end
 
       # Manufacturer of the device. Represents the hardware brand, which may differ from the provider.
@@ -1779,6 +2643,13 @@ module Seam
       attr_accessor :can_unlock_with_code
       # Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
       # @return [Array<String>]
+      # Known values:
+      # - `access_code`
+      # - `lock`
+      # - `noise_detection`
+      # - `thermostat`
+      # - `battery`
+      # - `phone`
       attr_accessor :capabilities_supported
       # Unique identifier for the account associated with the device.
       # @return [String]
@@ -1791,6 +2662,50 @@ module Seam
       attr_accessor :device_id
       # Type of the device.
       # @return [String]
+      # Known values:
+      # - `akuvox_lock`
+      # - `august_lock`
+      # - `brivo_access_point`
+      # - `butterflymx_panel`
+      # - `avigilon_alta_entry`
+      # - `doorking_lock`
+      # - `genie_door`
+      # - `igloo_lock`
+      # - `linear_lock`
+      # - `lockly_lock`
+      # - `kwikset_lock`
+      # - `nuki_lock`
+      # - `salto_lock`
+      # - `schlage_lock`
+      # - `smartthings_lock`
+      # - `wyze_lock`
+      # - `yale_lock`
+      # - `two_n_intercom`
+      # - `controlbyweb_device`
+      # - `ttlock_lock`
+      # - `igloohome_lock`
+      # - `four_suites_door`
+      # - `dormakaba_oracode_door`
+      # - `tedee_lock`
+      # - `akiles_lock`
+      # - `ultraloq_lock`
+      # - `yacan_lock`
+      # - `keyincode_lock`
+      # - `omnitec_lock`
+      # - `kisi_lock`
+      # - `aqara_lock`
+      # - `keynest_key`
+      # - `noiseaware_activity_zone`
+      # - `minut_sensor`
+      # - `ecobee_thermostat`
+      # - `nest_thermostat`
+      # - `honeywell_resideo_thermostat`
+      # - `tado_thermostat`
+      # - `sensi_thermostat`
+      # - `smartthings_thermostat`
+      # - `ios_phone`
+      # - `android_phone`
+      # - `ring_camera`
       attr_accessor :device_type
       # Display name of the device, defaults to nickname (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the device easily, especially when there are numerous devices.
       # @return [String]

--- a/lib/seam/resources/device_provider.rb
+++ b/lib/seam/resources/device_provider.rb
@@ -65,6 +65,71 @@ module Seam
       attr_accessor :can_unlock_with_code
       # Name of the device provider.
       # @return [String]
+      # Known values:
+      # - `hotek`
+      # - `dormakaba_community`
+      # - `legic_connect`
+      # - `akuvox`
+      # - `august`
+      # - `avigilon_alta`
+      # - `brivo`
+      # - `butterflymx`
+      # - `schlage`
+      # - `smartthings`
+      # - `yale`
+      # - `genie`
+      # - `doorking`
+      # - `salto`
+      # - `salto_ks`
+      # - `salto_ks_accept`
+      # - `lockly`
+      # - `ttlock`
+      # - `linear`
+      # - `noiseaware`
+      # - `nuki`
+      # - `igloo`
+      # - `kwikset`
+      # - `minut`
+      # - `my_2n`
+      # - `controlbyweb`
+      # - `nest`
+      # - `igloohome`
+      # - `ecobee`
+      # - `four_suites`
+      # - `dormakaba_oracode`
+      # - `pti`
+      # - `wyze`
+      # - `seam_passport`
+      # - `visionline`
+      # - `assa_abloy_credential_service`
+      # - `tedee`
+      # - `honeywell_resideo`
+      # - `first_alert`
+      # - `latch`
+      # - `akiles`
+      # - `assa_abloy_vostio`
+      # - `assa_abloy_vostio_credential_service`
+      # - `tado`
+      # - `salto_space`
+      # - `sensi`
+      # - `keynest`
+      # - `korelock`
+      # - `keyincode`
+      # - `dormakaba_ambiance`
+      # - `ultraloq`
+      # - `yacan`
+      # - `dusaw`
+      # - `sifely`
+      # - `thirty_three_lock`
+      # - `ring`
+      # - `ical`
+      # - `lodgify`
+      # - `hostaway`
+      # - `guesty`
+      # - `acuity_scheduling`
+      # - `omnitec`
+      # - `kisi`
+      # - `aqara`
       attr_accessor :device_provider_name
       # Display name for the device provider.
       # @return [String]
@@ -74,6 +139,15 @@ module Seam
       attr_accessor :image_url
       # List of provider categories to which the device provider belongs, such as `stable`, `consumer_smartlocks`, `thermostats`, and so on.
       # @return [Array<String>]
+      # Known values:
+      # - `stable`
+      # - `consumer_smartlocks`
+      # - `beta`
+      # - `thermostats`
+      # - `noise_sensors`
+      # - `access_control_systems`
+      # - `cameras`
+      # - `connectors`
       attr_accessor :provider_categories
     end
   end

--- a/lib/seam/resources/event.rb
+++ b/lib/seam/resources/event.rb
@@ -2,404 +2,5182 @@
 
 module Seam
   module Resources
+    # Represents a Seam event. Known event types load as subclasses; unknown event types remain SeamEvent instances for forward compatibility.
     class SeamEvent < BaseResource
-      class AccessCodeErrors < BaseResource
-        # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was created.
+      class AccessCodeCreated < SeamEvent
+        # ID of the affected access code.
         # @return [String]
-        attr_accessor :error_code
-        # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Date and time at which Seam created the error.
-        # @return [Time]
-        date_accessor :created_at
-      end
-
-      class AccessCodeWarnings < BaseResource
-        # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
-        # @return [String]
-        attr_accessor :warning_code
-        # Date and time at which Seam created the warning.
-        # @return [Time]
-        date_accessor :created_at
-      end
-
-      class AcsSystemErrors < BaseResource
-        # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-        # @return [String]
-        attr_accessor :error_code
-        # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
-        # @return [String]
-        attr_accessor :message
-        # Date and time at which Seam created the error.
-        # @return [Time]
-        date_accessor :created_at
-      end
-
-      class AcsSystemWarnings < BaseResource
-        # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
-        # @return [String]
-        attr_accessor :message
-        # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
-        # @return [String]
-        attr_accessor :warning_code
-        # Date and time at which Seam created the warning.
-        # @return [Time]
-        date_accessor :created_at
-      end
-
-      class ChangedProperties < BaseResource
-        # Previous value of the property, or null if not set.
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
         # @return [String, nil]
-        attr_accessor :from
-        # Name of the property that changed (e.g. `code`).
+        attr_accessor :event_description
+        # ID of the event.
         # @return [String]
-        attr_accessor :property
-        # New value of the property, or null if cleared.
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed.
+      class AccessCodeChanged < SeamEvent
+        class ChangedProperties < BaseResource
+          # Previous value of the property, or null if not set.
+          # @return [String, nil]
+          attr_accessor :from
+          # Name of the property that changed (e.g. `code`).
+          # @return [String]
+          attr_accessor :property
+          # New value of the property, or null if cleared.
+          # @return [String, nil]
+          attr_accessor :to
+        end
+
+        # List of properties that changed on the access code.
+        # @return [Array<ChangedProperties>]
+        resource_list_accessor :changed_properties, ChangedProperties
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Human-readable reason for the change (e.g. `ongoing code auto-renewed`).
         # @return [String, nil]
-        attr_accessor :to
-      end
-
-      class ConnectedAccountErrors < BaseResource
-        # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        attr_accessor :change_reason
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
         # @return [String]
-        attr_accessor :error_code
-        # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Date and time at which Seam created the error.
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
         # @return [Time]
         date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class ConnectedAccountWarnings < BaseResource
-        # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      # The name of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+      class AccessCodeNameChanged < SeamEvent
+        class From < BaseResource
+          # Previous name of the access code.
+          # @return [String, nil]
+          attr_accessor :name
+        end
+
+        class To < BaseResource
+          # New name of the access code.
+          # @return [String, nil]
+          attr_accessor :name
+        end
+
+        # Previous access code name configuration.
+        # @return [From]
+        resource_accessor :from, From
+        # New access code name configuration.
+        # @return [To]
+        resource_accessor :to, To
+        # ID of the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
         # @return [String]
-        attr_accessor :warning_code
-        # Date and time at which Seam created the warning.
+        attr_accessor :connected_account_id
+        # Human-readable description of the change and its source.
+        # @return [String]
+        attr_accessor :description
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.name_changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
         # @return [Time]
         date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class DeviceErrors < BaseResource
-        # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+      # The pin code of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+      class AccessCodeCodeChanged < SeamEvent
+        class From < BaseResource
+          # Previous pin code.
+          # @return [String, nil]
+          attr_accessor :code
+        end
+
+        class To < BaseResource
+          # New pin code.
+          # @return [String, nil]
+          attr_accessor :code
+        end
+
+        # Previous pin code configuration.
+        # @return [From]
+        resource_accessor :from, From
+        # New pin code configuration.
+        # @return [To]
+        resource_accessor :to, To
+        # ID of the affected access code.
         # @return [String]
-        attr_accessor :error_code
-        # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Date and time at which Seam created the error.
+        attr_accessor :connected_account_id
+        # Human-readable description of the change and its source.
+        # @return [String]
+        attr_accessor :description
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.code_changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
         # @return [Time]
         date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class DeviceWarnings < BaseResource
-        # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+      # The time frame of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+      class AccessCodeTimeFrameChanged < SeamEvent
+        class From < BaseResource
+          # Previous end time.
+          # @return [String, nil]
+          attr_accessor :ends_at
+          # Previous start time.
+          # @return [String, nil]
+          attr_accessor :starts_at
+        end
+
+        class To < BaseResource
+          # New end time.
+          # @return [String, nil]
+          attr_accessor :ends_at
+          # New start time.
+          # @return [String, nil]
+          attr_accessor :starts_at
+        end
+
+        # Previous time frame configuration.
+        # @return [From]
+        resource_accessor :from, From
+        # New time frame configuration.
+        # @return [To]
+        resource_accessor :to, To
+        # ID of the affected access code.
         # @return [String]
-        attr_accessor :message
-        # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
         # @return [String]
-        attr_accessor :warning_code
-        # Date and time at which Seam created the warning.
+        attr_accessor :connected_account_id
+        # Human-readable description of the change and its source.
+        # @return [String]
+        attr_accessor :description
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.time_frame_changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
         # @return [Time]
         date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class From < BaseResource
-        # Previous pin code.
+      # Mutations were requested on an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). This event fires at request time, before the change is confirmed on the device.
+      class AccessCodeMutationsRequested < SeamEvent
+        class RequestedMutations < BaseResource
+          # Previous property values before the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+          # @return [Hash, nil]
+          attr_accessor :from
+          # Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+          # @return [String]
+          # Known values:
+          # - `updating_name`
+          # - `updating_code`
+          # - `updating_time_frame`
+          # - `deleting`
+          # - `creating`
+          # - `deferring_creation`
+          attr_accessor :mutation_code
+          # New property values after the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+          # @return [Hash, nil]
+          attr_accessor :to
+        end
+
+        # Array of mutations requested on the access code, each containing the mutation type and from/to values.
+        # @return [Array<RequestedMutations>]
+        resource_list_accessor :requested_mutations, RequestedMutations
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.mutations_requested`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) on a device.
+      class AccessCodeScheduledOnDevice < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Code for the affected access code.
+        # @return [String]
+        attr_accessor :code
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.scheduled_on_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was set on a device.
+      class AccessCodeSetOnDevice < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Code for the affected access code.
+        # @return [String]
+        attr_accessor :code
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.set_on_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was removed from a device.
+      class AccessCodeRemovedFromDevice < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.removed_from_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # There was an unusually long delay in setting an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) on a device.
+      class AccessCodeDelayInSettingOnDevice < SeamEvent
+        class AccessCodeErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AccessCodeWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access code.
+        # @return [Array<AccessCodeErrors>]
+        resource_list_accessor :access_code_errors, AccessCodeErrors
+        # Warnings associated with the access code.
+        # @return [Array<AccessCodeWarnings>]
+        resource_list_accessor :access_code_warnings, AccessCodeWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.delay_in_setting_on_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) failed to be set on a device.
+      class AccessCodeFailedToSetOnDevice < SeamEvent
+        class AccessCodeErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AccessCodeWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access code.
+        # @return [Array<AccessCodeErrors>]
+        resource_list_accessor :access_code_errors, AccessCodeErrors
+        # Warnings associated with the access code.
+        # @return [Array<AccessCodeWarnings>]
+        resource_list_accessor :access_code_warnings, AccessCodeWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.failed_to_set_on_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was deleted.
+      class AccessCodeDeleted < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Code for the affected access code.
         # @return [String, nil]
         attr_accessor :code
-        # Previous end time.
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # There was an unusually long delay in removing an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) from a device.
+      class AccessCodeDelayInRemovingFromDevice < SeamEvent
+        class AccessCodeErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AccessCodeWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access code.
+        # @return [Array<AccessCodeErrors>]
+        resource_list_accessor :access_code_errors, AccessCodeErrors
+        # Warnings associated with the access code.
+        # @return [Array<AccessCodeWarnings>]
+        resource_list_accessor :access_code_warnings, AccessCodeWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.delay_in_removing_from_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) failed to be removed from a device.
+      class AccessCodeFailedToRemoveFromDevice < SeamEvent
+        class AccessCodeErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AccessCodeWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access code.
+        # @return [Array<AccessCodeErrors>]
+        resource_list_accessor :access_code_errors, AccessCodeErrors
+        # Warnings associated with the access code.
+        # @return [Array<AccessCodeWarnings>]
+        resource_list_accessor :access_code_warnings, AccessCodeWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.failed_to_remove_from_device`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was modified outside of Seam.
+      class AccessCodeModifiedExternalToSeam < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.modified_external_to_seam`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was deleted outside of Seam.
+      class AccessCodeDeletedExternalToSeam < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.deleted_external_to_seam`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [backup access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.
+      class AccessCodeBackupAccessCodePulled < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # ID of the backup access code that was pulled from the pool.
+        # @return [String]
+        attr_accessor :backup_access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.backup_access_code_pulled`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.
+      class AccessCodeUnmanagedConvertedToManaged < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.unmanaged.converted_to_managed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.
+      class AccessCodeUnmanagedFailedToConvertToManaged < SeamEvent
+        class AccessCodeErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AccessCodeWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access code.
+        # @return [Array<AccessCodeErrors>]
+        resource_list_accessor :access_code_errors, AccessCodeErrors
+        # Warnings associated with the access code.
+        # @return [Array<AccessCodeWarnings>]
+        resource_list_accessor :access_code_warnings, AccessCodeWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.unmanaged.failed_to_convert_to_managed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.
+      class AccessCodeUnmanagedCreated < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.unmanaged.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.
+      class AccessCodeUnmanagedRemoved < SeamEvent
+        # ID of the affected access code.
+        # @return [String]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the affected access code.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the device associated with the affected access code.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_code.unmanaged.removed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An Access Grant was created.
+      class AccessGrantCreated < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An Access Grant was deleted.
+      class AccessGrantDeleted < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # All access requested for an Access Grant was successfully granted.
+      class AccessGrantAccessGrantedToAllDoors < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.access_granted_to_all_doors`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Access requested as part of an Access Grant to a particular door was successfully granted.
+      class AccessGrantAccessGrantedToDoor < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # ID of the affected [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        # @return [String]
+        attr_accessor :acs_entrance_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.access_granted_to_door`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Access to a particular door that was requested as part of an Access Grant was lost.
+      class AccessGrantAccessToDoorLost < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # ID of the affected [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        # @return [String]
+        attr_accessor :acs_entrance_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.access_to_door_lost`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An Access Grant's start or end time was changed.
+      class AccessGrantAccessTimesChanged < SeamEvent
+        # ID of the affected Access Grant.
+        # @return [String]
+        attr_accessor :access_grant_id
+        # Key of the affected Access Grant (if present).
+        # @return [String, nil]
+        attr_accessor :access_grant_key
+        # The new end time for the access grant.
         # @return [String, nil]
         attr_accessor :ends_at
-        # Previous name of the access code.
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
         # @return [String, nil]
-        attr_accessor :name
-        # Previous start time.
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.access_times_changed`
+        attr_accessor :event_type
+        # The new start time for the access grant.
         # @return [String, nil]
         attr_accessor :starts_at
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class Reason < BaseResource
-        # Human-readable explanation of why access was denied.
+      # One or more requested access methods could not be created for an Access Grant.
+      class AccessGrantCouldNotCreateRequestedAccessMethods < SeamEvent
+        # ID of the affected Access Grant.
         # @return [String]
-        attr_accessor :message
-        # Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+        attr_accessor :access_grant_id
+        # Description of why the access methods could not be created.
         # @return [String]
-        attr_accessor :reason_code
+        attr_accessor :error_message
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_grant.could_not_create_requested_access_methods`
+        attr_accessor :event_type
+        # IDs of the devices that did not receive a requested access method. Use these to identify which specific devices failed without having to fetch the Access Grant.
+        # @return [Array<String>]
+        attr_accessor :missing_device_ids
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      class RequestedMutations < BaseResource
-        # Previous property values before the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
-        # @return [Hash, nil]
-        attr_accessor :from
-        # Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+      # An access method was issued.
+      class AccessMethodIssued < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
         # @return [String]
-        attr_accessor :mutation_code
-        # New property values after the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
-        # @return [Hash, nil]
-        attr_accessor :to
-      end
-
-      class To < BaseResource
-        # New pin code.
+        attr_accessor :access_method_id
+        # The actual PIN code for code access methods (only present when mode is 'code').
         # @return [String, nil]
         attr_accessor :code
-        # New end time.
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
         # @return [String, nil]
-        attr_accessor :ends_at
-        # New name of the access code.
-        # @return [String, nil]
-        attr_accessor :name
-        # New start time.
-        # @return [String, nil]
-        attr_accessor :starts_at
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.issued`
+        attr_accessor :event_type
+        # Indicates whether the code is a backup code (only present when mode is 'code' and a backup code was used).
+        # @return [Boolean, nil]
+        attr_accessor :is_backup_code
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
       end
 
-      # @return [From]
-      resource_accessor :from, From
-      # Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
-      # @return [Reason, nil]
-      resource_accessor :reason, Reason
-      # @return [To]
-      resource_accessor :to, To
-      # Errors associated with the access code.
-      # @return [Array<AccessCodeErrors>]
-      resource_list_accessor :access_code_errors, AccessCodeErrors
-      # Warnings associated with the access code.
-      # @return [Array<AccessCodeWarnings>]
-      resource_list_accessor :access_code_warnings, AccessCodeWarnings
-      # Errors associated with the access control system.
-      # @return [Array<AcsSystemErrors>]
-      resource_list_accessor :acs_system_errors, AcsSystemErrors
-      # Warnings associated with the access control system.
-      # @return [Array<AcsSystemWarnings>]
-      resource_list_accessor :acs_system_warnings, AcsSystemWarnings
-      # List of properties that changed on the access code.
-      # @return [Array<ChangedProperties>]
-      resource_list_accessor :changed_properties, ChangedProperties
-      # Errors associated with the connected account.
-      # @return [Array<ConnectedAccountErrors>]
-      resource_list_accessor :connected_account_errors, ConnectedAccountErrors
-      # Warnings associated with the connected account.
-      # @return [Array<ConnectedAccountWarnings>]
-      resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
-      # Errors associated with the device.
-      # @return [Array<DeviceErrors>]
-      resource_list_accessor :device_errors, DeviceErrors
-      # Warnings associated with the device.
-      # @return [Array<DeviceWarnings>]
-      resource_list_accessor :device_warnings, DeviceWarnings
-      # Array of mutations requested on the access code, each containing the mutation type and from/to values.
-      # @return [Array<RequestedMutations>]
-      resource_list_accessor :requested_mutations, RequestedMutations
-      # @return [String, nil]
-      attr_accessor :access_code_id
-      # Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
-      # @return [Boolean, nil]
-      attr_accessor :access_code_is_managed
-      # ID of the affected Access Grant.
-      # @return [String]
-      attr_accessor :access_grant_id
-      # IDs of the access grants associated with this access method.
-      # @return [Array<String>]
-      attr_accessor :access_grant_ids
-      # Key of the affected Access Grant (if present).
-      # @return [String, nil]
-      attr_accessor :access_grant_key
-      # Keys of the access grants associated with this access method (if present).
-      # @return [Array<String>]
-      attr_accessor :access_grant_keys
-      # ID of the affected access method.
-      # @return [String]
-      attr_accessor :access_method_id
-      # ID of the affected access group.
-      # @return [String]
-      attr_accessor :acs_access_group_id
-      # ID of the affected credential.
-      # @return [String]
-      attr_accessor :acs_credential_id
-      # ID of the affected encoder.
-      # @return [String]
-      attr_accessor :acs_encoder_id
-      # @return [String]
-      attr_accessor :acs_entrance_id
-      # @return [Array<String>]
-      attr_accessor :acs_entrance_ids
-      # ID of the access system.
-      # @return [String]
-      attr_accessor :acs_system_id
-      # ID of the affected access system user.
-      # @return [String]
-      attr_accessor :acs_user_id
-      # @return [String, nil]
-      attr_accessor :action_attempt_id
-      # Type of the action.
-      # @return [String]
-      attr_accessor :action_type
-      # The reason the camera was activated.
-      # @return [String]
-      attr_accessor :activation_reason
-      # ID of the backup access code that was pulled from the pool.
-      # @return [String]
-      attr_accessor :backup_access_code_id
-      # Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
-      # @return [Float]
-      attr_accessor :battery_level
-      # Battery status of the affected device, calculated from the numeric `battery_level` value.
-      # @return [String]
-      attr_accessor :battery_status
-      # Human-readable reason for the change (e.g. `ongoing code auto-renewed`).
-      # @return [String, nil]
-      attr_accessor :change_reason
-      # ID of the affected client session.
-      # @return [String]
-      attr_accessor :client_session_id
-      # Key of the climate preset that was activated.
-      # @return [String]
-      attr_accessor :climate_preset_key
-      # @return [String, nil]
-      attr_accessor :code
-      # @return [String, nil]
-      attr_accessor :connect_webview_id
-      # @return [Hash{String => String, Boolean}, nil]
-      attr_accessor :connected_account_custom_metadata
-      # @return [String, nil]
-      attr_accessor :connected_account_id
-      # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
-      # @return [Float, nil]
-      attr_accessor :cooling_set_point_celsius
-      # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
-      # @return [Float, nil]
-      attr_accessor :cooling_set_point_fahrenheit
-      # @return [String, nil]
-      attr_accessor :customer_key
-      # Human-readable description of the change and its source.
-      # @return [String]
-      attr_accessor :description
-      # Desired temperature, in °C, defined by the affected thermostat's cooling or heating set point.
-      # @return [Float, nil]
-      attr_accessor :desired_temperature_celsius
-      # Desired temperature, in °F, defined by the affected thermostat's cooling or heating set point.
-      # @return [Float, nil]
-      attr_accessor :desired_temperature_fahrenheit
-      # @return [Hash{String => String, Boolean}, nil]
-      attr_accessor :device_custom_metadata
-      # @return [String, nil]
-      attr_accessor :device_id
-      # @return [Array<String>]
-      attr_accessor :device_ids
-      # @return [String, nil]
-      attr_accessor :device_name
-      # The new end time for the access grant.
-      # @return [String, nil]
-      attr_accessor :ends_at
-      # Error code associated with the disconnection event, if any.
-      # @return [String]
-      attr_accessor :error_code
-      # Description of why the access methods could not be created.
-      # @return [String]
-      attr_accessor :error_message
+      # An access method was revoked.
+      class AccessMethodRevoked < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.revoked`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An access method representing a physical card requires encoding.
+      class AccessMethodCardEncodingRequired < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.card_encoding_required`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An access method was deleted.
+      class AccessMethodDeleted < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An access method was reissued.
+      class AccessMethodReissued < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # The actual PIN code for code access methods (only present when mode is 'code').
+        # @return [String, nil]
+        attr_accessor :code
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.reissued`
+        attr_accessor :event_type
+        # Indicates whether the code is a backup code (only present when mode is 'code' and a backup code was used).
+        # @return [Boolean, nil]
+        attr_accessor :is_backup_code
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An access method was created.
+      class AccessMethodCreated < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam has not yet issued this access method, even though its access grant is about to begin, so access may not be ready when the recipient arrives. Seam is still attempting to issue it, and the accompanying `delay_in_issuing` warning clears automatically once issuance succeeds.
+      class AccessMethodDelayInIssuing < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.delay_in_issuing`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam was unable to issue this access method before its access grant started, so the recipient may be unable to access the space. This usually points to a problem that needs attention, such as an offline or disconnected device. Seam keeps retrying, and the accompanying `failed_to_issue` error clears automatically if the access method is eventually issued.
+      class AccessMethodFailedToIssue < SeamEvent
+        # IDs of the access grants associated with this access method.
+        # @return [Array<String>]
+        attr_accessor :access_grant_ids
+        # Keys of the access grants associated with this access method (if present).
+        # @return [Array<String>]
+        attr_accessor :access_grant_keys
+        # ID of the affected access method.
+        # @return [String]
+        attr_accessor :access_method_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `access_method.failed_to_issue`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system](https://docs.seam.co/low-level-apis/access-systems) was connected.
+      class AcsSystemConnected < SeamEvent
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_system.connected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system](https://docs.seam.co/low-level-apis/access-systems) was added.
+      class AcsSystemAdded < SeamEvent
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_system.added`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system](https://docs.seam.co/low-level-apis/access-systems) was disconnected.
+      class AcsSystemDisconnected < SeamEvent
+        class AcsSystemErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class AcsSystemWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the access control system.
+        # @return [Array<AcsSystemErrors>]
+        resource_list_accessor :acs_system_errors, AcsSystemErrors
+        # Warnings associated with the access control system.
+        # @return [Array<AcsSystemWarnings>]
+        resource_list_accessor :acs_system_warnings, AcsSystemWarnings
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_system.disconnected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was deleted.
+      class AcsCredentialDeleted < SeamEvent
+        # ID of the affected credential.
+        # @return [String]
+        attr_accessor :acs_credential_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_credential.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was issued.
+      class AcsCredentialIssued < SeamEvent
+        # ID of the affected credential.
+        # @return [String]
+        attr_accessor :acs_credential_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_credential.issued`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was reissued.
+      class AcsCredentialReissued < SeamEvent
+        # ID of the affected credential.
+        # @return [String]
+        attr_accessor :acs_credential_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_credential.reissued`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.
+      class AcsCredentialInvalidated < SeamEvent
+        # ID of the affected credential.
+        # @return [String]
+        attr_accessor :acs_credential_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_credential.invalidated`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created.
+      class AcsUserCreated < SeamEvent
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the affected access system user.
+        # @return [String]
+        attr_accessor :acs_user_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_user.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was deleted.
+      class AcsUserDeleted < SeamEvent
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the affected access system user.
+        # @return [String]
+        attr_accessor :acs_user_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_user.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was added.
+      class AcsEncoderAdded < SeamEvent
+        # ID of the affected encoder.
+        # @return [String]
+        attr_accessor :acs_encoder_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_encoder.added`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was removed.
+      class AcsEncoderRemoved < SeamEvent
+        # ID of the affected encoder.
+        # @return [String]
+        attr_accessor :acs_encoder_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_encoder.removed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An ACS access group was deleted.
+      class AcsAccessGroupDeleted < SeamEvent
+        # ID of the affected access group.
+        # @return [String]
+        attr_accessor :acs_access_group_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_access_group.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was added.
+      class AcsEntranceAdded < SeamEvent
+        # ID of the affected entrance.
+        # @return [String]
+        attr_accessor :acs_entrance_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_entrance.added`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was removed.
+      class AcsEntranceRemoved < SeamEvent
+        # ID of the affected entrance.
+        # @return [String]
+        attr_accessor :acs_entrance_id
+        # ID of the access system.
+        # @return [String]
+        attr_accessor :acs_system_id
+        # ID of the connected account.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `acs_entrance.removed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A client session was deleted.
+      class ClientSessionDeleted < SeamEvent
+        # ID of the affected client session.
+        # @return [String]
+        attr_accessor :client_session_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `client_session.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account was connected for the first time or was reconnected after being disconnected.
+      class ConnectedAccountConnected < SeamEvent
+        # ID of the Connect Webview associated with the event.
+        # @return [String, nil]
+        attr_accessor :connect_webview_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with this connected account, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.connected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account was created.
+      class ConnectedAccountCreated < SeamEvent
+        # ID of the Connect Webview associated with the event.
+        # @return [String]
+        attr_accessor :connect_webview_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.created`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account had a successful login using a Connect Webview.
+      class ConnectedAccountSuccessfulLogin < SeamEvent
+        # ID of the Connect Webview associated with the event.
+        # @return [String]
+        attr_accessor :connect_webview_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.successful_login`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account was disconnected.
+      class ConnectedAccountDisconnected < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.disconnected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account completed the first sync with Seam, and the corresponding devices or systems are now available.
+      class ConnectedAccountCompletedFirstSync < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.completed_first_sync`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account was deleted.
+      class ConnectedAccountDeleted < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with this connected account, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.
+      class ConnectedAccountCompletedFirstSyncAfterReconnection < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.completed_first_sync_after_reconnection`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A connected account requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.
+      class ConnectedAccountReauthorizationRequested < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the affected connected account.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connected_account.reauthorization_requested`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A lock door action attempt succeeded.
+      class ActionAttemptLockDoorSucceeded < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.lock_door.succeeded`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A lock door action attempt failed.
+      class ActionAttemptLockDoorFailed < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.lock_door.failed`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An unlock door action attempt succeeded.
+      class ActionAttemptUnlockDoorSucceeded < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.unlock_door.succeeded`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An unlock door action attempt failed.
+      class ActionAttemptUnlockDoorFailed < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.unlock_door.failed`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A simulate keypad code entry action attempt succeeded.
+      class ActionAttemptSimulateKeypadCodeEntrySucceeded < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.simulate_keypad_code_entry.succeeded`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A simulate keypad code entry action attempt failed.
+      class ActionAttemptSimulateKeypadCodeEntryFailed < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.simulate_keypad_code_entry.failed`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A simulate manual lock via keypad action attempt succeeded.
+      class ActionAttemptSimulateManualLockViaKeypadSucceeded < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.simulate_manual_lock_via_keypad.succeeded`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A simulate manual lock via keypad action attempt failed.
+      class ActionAttemptSimulateManualLockViaKeypadFailed < SeamEvent
+        # ID of the affected action attempt.
+        # @return [String]
+        attr_accessor :action_attempt_id
+        # Type of the action.
+        # @return [String]
+        attr_accessor :action_type
+        # ID of the connected account associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :connected_account_id
+        # ID of the device associated with the action attempt, if applicable.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `action_attempt.simulate_manual_lock_via_keypad.failed`
+        attr_accessor :event_type
+        # Status of the action.
+        # @return [String]
+        attr_accessor :status
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A Connect Webview login succeeded.
+      class ConnectWebviewLoginSucceeded < SeamEvent
+        # ID of the affected Connect Webview.
+        # @return [String]
+        attr_accessor :connect_webview_id
+        # Custom metadata of the connected account; present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with this connect webview, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connect_webview.login_succeeded`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A Connect Webview login failed.
+      class ConnectWebviewLoginFailed < SeamEvent
+        # ID of the affected Connect Webview.
+        # @return [String]
+        attr_accessor :connect_webview_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `connect_webview.login_failed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The status of a device changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`. Note that some devices operate entirely in offline mode, so Seam never emits a `device.connected` event for these devices.
+      class DeviceConnected < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.connected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device was added to Seam or was re-added to Seam after having been removed.
+      class DeviceAdded < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.added`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+      class DeviceConvertedToUnmanaged < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.converted_to_unmanaged`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.
+      class DeviceUnmanagedConvertedToManaged < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.unmanaged.converted_to_managed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`.
+      class DeviceUnmanagedConnected < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.unmanaged.connected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The status of a device changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.
+      class DeviceDisconnected < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Error code associated with the disconnection event, if any.
+        # @return [String]
+        # Known values:
+        # - `account_disconnected`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        attr_accessor :error_code
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.disconnected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.
+      class DeviceUnmanagedDisconnected < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Error code associated with the disconnection event, if any.
+        # @return [String]
+        # Known values:
+        # - `account_disconnected`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        attr_accessor :error_code
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.unmanaged.disconnected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device detected that it was tampered with, for example, opened or moved.
+      class DeviceTampered < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.tampered`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device battery level dropped below the low threshold.
+      class DeviceLowBattery < SeamEvent
+        # Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
+        # @return [Float]
+        attr_accessor :battery_level
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.low_battery`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device battery status changed since the last `battery_status_changed` event.
+      class DeviceBatteryStatusChanged < SeamEvent
+        # Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
+        # @return [Float]
+        attr_accessor :battery_level
+        # Battery status of the affected device, calculated from the numeric `battery_level` value.
+        # @return [String]
+        # Known values:
+        # - `critical`
+        # - `low`
+        # - `good`
+        # - `full`
+        attr_accessor :battery_status
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.battery_status_changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device was removed externally from the connected account.
+      class DeviceRemoved < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.removed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device was deleted.
+      class DeviceDeleted < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Name of the deleted device, captured at deletion time. The device record no longer exists when this event fires, so the name is preserved here. Null when the device had no resolvable name.
+        # @return [String, nil]
+        attr_accessor :device_name
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.deleted`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam detected that a device is using a third-party integration that will interfere with Seam device management.
+      class DeviceThirdPartyIntegrationDetected < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.third_party_integration_detected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam detected that a device is no longer using a third-party integration that was interfering with Seam device management.
+      class DeviceThirdPartyIntegrationNoLongerDetected < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.third_party_integration_no_longer_detected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) activated privacy mode.
+      class DeviceSaltoPrivacyModeActivated < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.salto.privacy_mode_activated`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) deactivated privacy mode.
+      class DeviceSaltoPrivacyModeDeactivated < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.salto.privacy_mode_deactivated`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam detected a flaky device connection.
+      class DeviceConnectionBecameFlaky < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.connection_became_flaky`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Seam detected that a previously-flaky device connection stabilized.
+      class DeviceConnectionStabilized < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.connection_stabilized`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A third-party subscription is required to use all device features.
+      class DeviceErrorSubscriptionRequired < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.error.subscription_required`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A third-party subscription is active or no longer required to use all device features.
+      class DeviceErrorSubscriptionRequiredResolved < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.error.subscription_required.resolved`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An accessory keypad was connected to a device.
+      class DeviceAccessoryKeypadConnected < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.accessory_keypad_connected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # An accessory keypad was disconnected from a device.
+      class DeviceAccessoryKeypadDisconnected < SeamEvent
+        class ConnectedAccountErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class ConnectedAccountWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceErrors < BaseResource
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        class DeviceWarnings < BaseResource
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Errors associated with the connected account.
+        # @return [Array<ConnectedAccountErrors>]
+        resource_list_accessor :connected_account_errors, ConnectedAccountErrors
+        # Warnings associated with the connected account.
+        # @return [Array<ConnectedAccountWarnings>]
+        resource_list_accessor :connected_account_warnings, ConnectedAccountWarnings
+        # Errors associated with the device.
+        # @return [Array<DeviceErrors>]
+        resource_list_accessor :device_errors, DeviceErrors
+        # Warnings associated with the device.
+        # @return [Array<DeviceWarnings>]
+        resource_list_accessor :device_warnings, DeviceWarnings
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.accessory_keypad_disconnected`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/capability-guides/noise-sensors#what-is-a-threshold) were detected.
+      class NoiseSensorNoiseThresholdTriggered < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `noise_sensor.noise_threshold_triggered`
+        attr_accessor :event_type
+        # Metadata from Minut.
+        # @return [Hash, nil]
+        attr_accessor :minut_metadata
+        # Detected noise level in decibels.
+        # @return [Float, nil]
+        attr_accessor :noise_level_decibels
+        # Detected noise level in Noiseaware Noise Risk Score (NRS).
+        # @return [Float, nil]
+        attr_accessor :noise_level_nrs
+        # ID of the noise threshold that was triggered.
+        # @return [String, nil]
+        attr_accessor :noise_threshold_id
+        # Name of the noise threshold that was triggered.
+        # @return [String, nil]
+        attr_accessor :noise_threshold_name
+        # Metadata from Noiseaware.
+        # @return [Hash, nil]
+        attr_accessor :noiseaware_metadata
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [lock](https://docs.seam.co/low-level-apis/smart-locks) was locked.
+      class LockLocked < SeamEvent
+        # ID of the access code that was used to lock the device.
+        # @return [String, nil]
+        attr_accessor :access_code_id
+        # Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
+        # @return [Boolean, nil]
+        attr_accessor :access_code_is_managed
+        # ID of the Seam action attempt that triggered this lock. Present only when the lock was initiated through Seam (via a `LOCK_DOOR` action attempt).
+        # @return [String, nil]
+        attr_accessor :action_attempt_id
+        # Code (PIN) that was used to lock the device, if known. Taken from the matched managed or unmanaged access code, or from the code reported by the provider when no access code matched.
+        # @return [String, nil]
+        attr_accessor :code
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `lock.locked`
+        attr_accessor :event_type
+        # Whether the lock action was performed over Bluetooth by a remote client (such as the provider's mobile app), rather than a direct physical interaction or a Seam-initiated remote action.
+        # @return [Boolean, nil]
+        attr_accessor :is_via_bluetooth
+        # Whether the lock action was performed by an NFC credential tap (such as an Apple Home Key or an NFC key fob) presented to the lock, rather than a direct physical interaction or a Seam-initiated remote action.
+        # @return [Boolean, nil]
+        attr_accessor :is_via_nfc
+        # Method by which the lock was locked. `keycode`: an access code was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or button press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by an auto-relock timer. `unknown`: could not be determined.
+        # @return [String]
+        # Known values:
+        # - `keycode`
+        # - `manual`
+        # - `automatic`
+        # - `unknown`
+        # - `remote`
+        # - `card`
+        aliased_accessor :event_method, from: :method
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [lock](https://docs.seam.co/low-level-apis/smart-locks) was unlocked.
+      class LockUnlocked < SeamEvent
+        # ID of the access code that was used to unlock the affected device.
+        # @return [String, nil]
+        attr_accessor :access_code_id
+        # Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
+        # @return [Boolean, nil]
+        attr_accessor :access_code_is_managed
+        # ID of the Seam action attempt that triggered this unlock. Present only when the unlock was initiated through Seam (via an `UNLOCK_DOOR` action attempt).
+        # @return [String, nil]
+        attr_accessor :action_attempt_id
+        # Code (PIN) that was used to unlock the affected device, if known. Taken from the matched managed or unmanaged access code, or from the code reported by the provider when no access code matched.
+        # @return [String, nil]
+        attr_accessor :code
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `lock.unlocked`
+        attr_accessor :event_type
+        # Whether the unlock action was performed over Bluetooth by a remote client (such as the provider's mobile app), rather than a direct physical interaction or a Seam-initiated remote action.
+        # @return [Boolean, nil]
+        attr_accessor :is_via_bluetooth
+        # Whether the unlock action was performed by an NFC credential tap (such as an Apple Home Key or an NFC key fob) presented to the lock, rather than a direct physical interaction or a Seam-initiated remote action.
+        # @return [Boolean, nil]
+        attr_accessor :is_via_nfc
+        # Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.
+        # @return [String]
+        # Known values:
+        # - `keycode`
+        # - `manual`
+        # - `automatic`
+        # - `unknown`
+        # - `remote`
+        # - `card`
+        aliased_accessor :event_method, from: :method
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The [lock](https://docs.seam.co/low-level-apis/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.
+      class LockAccessDenied < SeamEvent
+        class Reason < BaseResource
+          # Human-readable explanation of why access was denied.
+          # @return [String]
+          attr_accessor :message
+          # Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+          # @return [String]
+          # Known values:
+          # - `unknown_code`
+          # - `expired_code`
+          # - `blocklisted_code`
+          # - `too_many_attempts`
+          # - `blocked_by_privacy_mode`
+          # - `credential_error`
+          attr_accessor :reason_code
+        end
+
+        # Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
+        # @return [Reason, nil]
+        resource_accessor :reason, Reason
+        # ID of the access code that was used in the unlock attempts.
+        # @return [String, nil]
+        attr_accessor :access_code_id
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String, nil]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `lock.access_denied`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A thermostat [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.
+      class ThermostatClimatePresetActivated < SeamEvent
+        # Key of the climate preset that was activated.
+        # @return [String]
+        attr_accessor :climate_preset_key
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.climate_preset_activated`
+        attr_accessor :event_type
+        # Indicates whether the climate preset that was activated is the fallback climate preset for the thermostat.
+        # @return [Boolean]
+        attr_accessor :is_fallback_climate_preset
+        # ID of the thermostat schedule that prompted the affected climate preset to be activated.
+        # @return [String, nil]
+        attr_accessor :thermostat_schedule_id
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [thermostat](https://docs.seam.co/capability-guides/thermostats) was adjusted manually.
+      class ThermostatManuallyAdjusted < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        # @return [Float, nil]
+        attr_accessor :cooling_set_point_celsius
+        # Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        # @return [Float, nil]
+        attr_accessor :cooling_set_point_fahrenheit
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.manually_adjusted`
+        attr_accessor :event_type
+        # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        # @return [String, nil]
+        # Known values:
+        # - `auto`
+        # - `on`
+        # - `circulate`
+        attr_accessor :fan_mode_setting
+        # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        # @return [Float, nil]
+        attr_accessor :heating_set_point_celsius
+        # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        # @return [Float, nil]
+        attr_accessor :heating_set_point_fahrenheit
+        # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        # @return [String, nil]
+        # Known values:
+        # - `off`
+        # - `heat`
+        # - `cool`
+        # - `heat_cool`
+        # - `eco`
+        attr_accessor :hvac_mode_setting
+        # Method used to adjust the affected thermostat manually. `seam` indicates that the Seam API, Seam CLI, or Seam Console was used to adjust the thermostat.
+        # @return [String]
+        # Known values:
+        # - `seam`
+        # - `external`
+        aliased_accessor :event_method, from: :method
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+      class ThermostatTemperatureThresholdExceeded < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.temperature_threshold_exceeded`
+        attr_accessor :event_type
+        # Lower temperature limit, in °C, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :lower_limit_celsius
+        # Lower temperature limit, in °F, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :lower_limit_fahrenheit
+        # Temperature, in °C, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_celsius
+        # Temperature, in °F, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_fahrenheit
+        # Upper temperature limit, in °C, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :upper_limit_celsius
+        # Upper temperature limit, in °F, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :upper_limit_fahrenheit
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+      class ThermostatTemperatureThresholdNoLongerExceeded < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.temperature_threshold_no_longer_exceeded`
+        attr_accessor :event_type
+        # Lower temperature limit, in °C, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :lower_limit_celsius
+        # Lower temperature limit, in °F, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :lower_limit_fahrenheit
+        # Temperature, in °C, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_celsius
+        # Temperature, in °F, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_fahrenheit
+        # Upper temperature limit, in °C, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :upper_limit_celsius
+        # Upper temperature limit, in °F, defined by the set threshold.
+        # @return [Float, nil]
+        attr_accessor :upper_limit_fahrenheit
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+      class ThermostatTemperatureReachedSetPoint < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Desired temperature, in °C, defined by the affected thermostat's cooling or heating set point.
+        # @return [Float, nil]
+        attr_accessor :desired_temperature_celsius
+        # Desired temperature, in °F, defined by the affected thermostat's cooling or heating set point.
+        # @return [Float, nil]
+        attr_accessor :desired_temperature_fahrenheit
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.temperature_reached_set_point`
+        attr_accessor :event_type
+        # Temperature, in °C, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_celsius
+        # Temperature, in °F, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_fahrenheit
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A [thermostat's](https://docs.seam.co/capability-guides/thermostats) reported temperature changed by at least 1 °C.
+      class ThermostatTemperatureChanged < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `thermostat.temperature_changed`
+        attr_accessor :event_type
+        # Temperature, in °C, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_celsius
+        # Temperature, in °F, reported by the affected thermostat.
+        # @return [Float]
+        attr_accessor :temperature_fahrenheit
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # The name of a device was changed.
+      class DeviceNameChanged < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # The new name of the affected device.
+        # @return [String]
+        attr_accessor :device_name
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.name_changed`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A camera was activated, for example, by motion detection.
+      class CameraActivated < SeamEvent
+        # The reason the camera was activated.
+        # @return [String]
+        # Known values:
+        # - `motion_detected`
+        attr_accessor :activation_reason
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `camera.activated`
+        attr_accessor :event_type
+        # URL to a thumbnail image captured at the time of activation.
+        # @return [String, nil]
+        attr_accessor :image_url
+        # Sub-type of motion detected, if available.
+        # @return [String, nil]
+        # Known values:
+        # - `human`
+        # - `vehicle`
+        # - `package`
+        # - `other`
+        attr_accessor :motion_sub_type
+        # URL to a short video clip captured at the time of activation.
+        # @return [String, nil]
+        attr_accessor :video_url
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A doorbell button was pressed on a device.
+      class DeviceDoorbellRang < SeamEvent
+        # Custom metadata of the connected account, present when connected_account_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :connected_account_custom_metadata
+        # ID of the connected account associated with the event.
+        # @return [String]
+        attr_accessor :connected_account_id
+        # The customer key associated with the device, if any.
+        # @return [String, nil]
+        attr_accessor :customer_key
+        # Custom metadata of the device, present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `device.doorbell_rang`
+        attr_accessor :event_type
+        # URL to a thumbnail image captured at the time the doorbell was pressed.
+        # @return [String, nil]
+        attr_accessor :image_url
+        # URL to a short video clip captured at the time the doorbell was pressed.
+        # @return [String, nil]
+        attr_accessor :video_url
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A phone device was deactivated.
+      class PhoneDeactivated < SeamEvent
+        # Custom metadata of the device; present when device_id is provided.
+        # @return [Hash{String => String, Boolean}, nil]
+        attr_accessor :device_custom_metadata
+        # ID of the affected phone device.
+        # @return [String]
+        attr_accessor :device_id
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # @return [String]
+        # Known values:
+        # - `phone.deactivated`
+        attr_accessor :event_type
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A device was added or removed from a space.
+      class SpaceDeviceMembershipChanged < SeamEvent
+        # IDs of all ACS entrances currently attached to the space.
+        # @return [Array<String>]
+        attr_accessor :acs_entrance_ids
+        # IDs of all devices currently attached to the space.
+        # @return [Array<String>]
+        attr_accessor :device_ids
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # Type of the event.
+        # @return [String]
+        # Known values:
+        # - `space.device_membership_changed`
+        attr_accessor :event_type
+        # ID of the affected space.
+        # @return [String]
+        attr_accessor :space_id
+        # Unique key for the space within the workspace.
+        # @return [String, nil]
+        attr_accessor :space_key
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A space was created.
+      class SpaceCreated < SeamEvent
+        # IDs of all ACS entrances attached to the space when it was created.
+        # @return [Array<String>]
+        attr_accessor :acs_entrance_ids
+        # IDs of all devices attached to the space when it was created.
+        # @return [Array<String>]
+        attr_accessor :device_ids
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # Type of the event.
+        # @return [String]
+        # Known values:
+        # - `space.created`
+        attr_accessor :event_type
+        # ID of the affected space.
+        # @return [String]
+        attr_accessor :space_id
+        # Unique key for the space within the workspace.
+        # @return [String, nil]
+        attr_accessor :space_key
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
+      # A space was deleted.
+      class SpaceDeleted < SeamEvent
+        # IDs of all ACS entrances currently attached to the space when it was deleted.
+        # @return [Array<String>]
+        attr_accessor :acs_entrance_ids
+        # IDs of all devices attached to the space when it was deleted.
+        # @return [Array<String>]
+        attr_accessor :device_ids
+        # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        # @return [String, nil]
+        attr_accessor :event_description
+        # ID of the event.
+        # @return [String]
+        attr_accessor :event_id
+        # Type of the event.
+        # @return [String]
+        # Known values:
+        # - `space.deleted`
+        attr_accessor :event_type
+        # ID of the affected space.
+        # @return [String]
+        attr_accessor :space_id
+        # Unique key for the space within the workspace.
+        # @return [String, nil]
+        attr_accessor :space_key
+        # ID of the workspace associated with the event.
+        # @return [String]
+        attr_accessor :workspace_id
+        # Date and time at which the event was created.
+        # @return [Time]
+        date_accessor :created_at
+        # Date and time at which the event occurred.
+        # @return [Time]
+        date_accessor :occurred_at
+      end
+
       # Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
       # @return [String, nil]
       attr_accessor :event_description
       # ID of the event.
       # @return [String, nil]
       attr_accessor :event_id
-      # Type of the event.
       # @return [String, nil]
+      # Known values:
+      # - `access_code.created`
+      # - `access_code.changed`
+      # - `access_code.name_changed`
+      # - `access_code.code_changed`
+      # - `access_code.time_frame_changed`
+      # - `access_code.mutations_requested`
+      # - `access_code.scheduled_on_device`
+      # - `access_code.set_on_device`
+      # - `access_code.removed_from_device`
+      # - `access_code.delay_in_setting_on_device`
+      # - `access_code.failed_to_set_on_device`
+      # - `access_code.deleted`
+      # - `access_code.delay_in_removing_from_device`
+      # - `access_code.failed_to_remove_from_device`
+      # - `access_code.modified_external_to_seam`
+      # - `access_code.deleted_external_to_seam`
+      # - `access_code.backup_access_code_pulled`
+      # - `access_code.unmanaged.converted_to_managed`
+      # - `access_code.unmanaged.failed_to_convert_to_managed`
+      # - `access_code.unmanaged.created`
+      # - `access_code.unmanaged.removed`
+      # - `access_grant.created`
+      # - `access_grant.deleted`
+      # - `access_grant.access_granted_to_all_doors`
+      # - `access_grant.access_granted_to_door`
+      # - `access_grant.access_to_door_lost`
+      # - `access_grant.access_times_changed`
+      # - `access_grant.could_not_create_requested_access_methods`
+      # - `access_method.issued`
+      # - `access_method.revoked`
+      # - `access_method.card_encoding_required`
+      # - `access_method.deleted`
+      # - `access_method.reissued`
+      # - `access_method.created`
+      # - `access_method.delay_in_issuing`
+      # - `access_method.failed_to_issue`
+      # - `acs_system.connected`
+      # - `acs_system.added`
+      # - `acs_system.disconnected`
+      # - `acs_credential.deleted`
+      # - `acs_credential.issued`
+      # - `acs_credential.reissued`
+      # - `acs_credential.invalidated`
+      # - `acs_user.created`
+      # - `acs_user.deleted`
+      # - `acs_encoder.added`
+      # - `acs_encoder.removed`
+      # - `acs_access_group.deleted`
+      # - `acs_entrance.added`
+      # - `acs_entrance.removed`
+      # - `client_session.deleted`
+      # - `connected_account.connected`
+      # - `connected_account.created`
+      # - `connected_account.successful_login`
+      # - `connected_account.disconnected`
+      # - `connected_account.completed_first_sync`
+      # - `connected_account.deleted`
+      # - `connected_account.completed_first_sync_after_reconnection`
+      # - `connected_account.reauthorization_requested`
+      # - `action_attempt.lock_door.succeeded`
+      # - `action_attempt.lock_door.failed`
+      # - `action_attempt.unlock_door.succeeded`
+      # - `action_attempt.unlock_door.failed`
+      # - `action_attempt.simulate_keypad_code_entry.succeeded`
+      # - `action_attempt.simulate_keypad_code_entry.failed`
+      # - `action_attempt.simulate_manual_lock_via_keypad.succeeded`
+      # - `action_attempt.simulate_manual_lock_via_keypad.failed`
+      # - `connect_webview.login_succeeded`
+      # - `connect_webview.login_failed`
+      # - `device.connected`
+      # - `device.added`
+      # - `device.converted_to_unmanaged`
+      # - `device.unmanaged.converted_to_managed`
+      # - `device.unmanaged.connected`
+      # - `device.disconnected`
+      # - `device.unmanaged.disconnected`
+      # - `device.tampered`
+      # - `device.low_battery`
+      # - `device.battery_status_changed`
+      # - `device.removed`
+      # - `device.deleted`
+      # - `device.third_party_integration_detected`
+      # - `device.third_party_integration_no_longer_detected`
+      # - `device.salto.privacy_mode_activated`
+      # - `device.salto.privacy_mode_deactivated`
+      # - `device.connection_became_flaky`
+      # - `device.connection_stabilized`
+      # - `device.error.subscription_required`
+      # - `device.error.subscription_required.resolved`
+      # - `device.accessory_keypad_connected`
+      # - `device.accessory_keypad_disconnected`
+      # - `noise_sensor.noise_threshold_triggered`
+      # - `lock.locked`
+      # - `lock.unlocked`
+      # - `lock.access_denied`
+      # - `thermostat.climate_preset_activated`
+      # - `thermostat.manually_adjusted`
+      # - `thermostat.temperature_threshold_exceeded`
+      # - `thermostat.temperature_threshold_no_longer_exceeded`
+      # - `thermostat.temperature_reached_set_point`
+      # - `thermostat.temperature_changed`
+      # - `device.name_changed`
+      # - `camera.activated`
+      # - `device.doorbell_rang`
+      # - `enrollment_automation.deleted`
+      # - `phone.deactivated`
+      # - `space.device_membership_changed`
+      # - `space.created`
+      # - `space.deleted`
       attr_accessor :event_type
-      # Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-      # @return [String, nil]
-      attr_accessor :fan_mode_setting
-      # Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
-      # @return [Float, nil]
-      attr_accessor :heating_set_point_celsius
-      # Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
-      # @return [Float, nil]
-      attr_accessor :heating_set_point_fahrenheit
-      # Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-      # @return [String, nil]
-      attr_accessor :hvac_mode_setting
-      # @return [String, nil]
-      attr_accessor :image_url
-      # Indicates whether the code is a backup code (only present when mode is 'code' and a backup code was used).
-      # @return [Boolean, nil]
-      attr_accessor :is_backup_code
-      # Indicates whether the climate preset that was activated is the fallback climate preset for the thermostat.
-      # @return [Boolean]
-      attr_accessor :is_fallback_climate_preset
-      # @return [Boolean, nil]
-      attr_accessor :is_via_bluetooth
-      # @return [Boolean, nil]
-      attr_accessor :is_via_nfc
-      # Lower temperature limit, in °C, defined by the set threshold.
-      # @return [Float, nil]
-      attr_accessor :lower_limit_celsius
-      # Lower temperature limit, in °F, defined by the set threshold.
-      # @return [Float, nil]
-      attr_accessor :lower_limit_fahrenheit
-      # @return [String]
-      attr_accessor :method
-      # Metadata from Minut.
-      # @return [Hash, nil]
-      attr_accessor :minut_metadata
-      # IDs of the devices that did not receive a requested access method. Use these to identify which specific devices failed without having to fetch the Access Grant.
-      # @return [Array<String>]
-      attr_accessor :missing_device_ids
-      # Sub-type of motion detected, if available.
-      # @return [String, nil]
-      attr_accessor :motion_sub_type
-      # Detected noise level in decibels.
-      # @return [Float, nil]
-      attr_accessor :noise_level_decibels
-      # Detected noise level in Noiseaware Noise Risk Score (NRS).
-      # @return [Float, nil]
-      attr_accessor :noise_level_nrs
-      # ID of the noise threshold that was triggered.
-      # @return [String, nil]
-      attr_accessor :noise_threshold_id
-      # Name of the noise threshold that was triggered.
-      # @return [String, nil]
-      attr_accessor :noise_threshold_name
-      # Metadata from Noiseaware.
-      # @return [Hash, nil]
-      attr_accessor :noiseaware_metadata
-      # ID of the affected space.
-      # @return [String]
-      attr_accessor :space_id
-      # Unique key for the space within the workspace.
-      # @return [String, nil]
-      attr_accessor :space_key
-      # The new start time for the access grant.
-      # @return [String, nil]
-      attr_accessor :starts_at
-      # Status of the action.
-      # @return [String]
-      attr_accessor :status
-      # Temperature, in °C, reported by the affected thermostat.
-      # @return [Float]
-      attr_accessor :temperature_celsius
-      # Temperature, in °F, reported by the affected thermostat.
-      # @return [Float]
-      attr_accessor :temperature_fahrenheit
-      # ID of the thermostat schedule that prompted the affected climate preset to be activated.
-      # @return [String, nil]
-      attr_accessor :thermostat_schedule_id
-      # Upper temperature limit, in °C, defined by the set threshold.
-      # @return [Float, nil]
-      attr_accessor :upper_limit_celsius
-      # Upper temperature limit, in °F, defined by the set threshold.
-      # @return [Float, nil]
-      attr_accessor :upper_limit_fahrenheit
-      # @return [String, nil]
-      attr_accessor :video_url
       # ID of the workspace associated with the event.
       # @return [String, nil]
       attr_accessor :workspace_id
@@ -411,6 +5189,117 @@ module Seam
       # Date and time at which the event occurred.
       # @return [Time, nil]
       date_accessor :occurred_at
+
+      discriminated_by :event_type, {
+        "access_code.created" => AccessCodeCreated,
+        "access_code.changed" => AccessCodeChanged,
+        "access_code.name_changed" => AccessCodeNameChanged,
+        "access_code.code_changed" => AccessCodeCodeChanged,
+        "access_code.time_frame_changed" => AccessCodeTimeFrameChanged,
+        "access_code.mutations_requested" => AccessCodeMutationsRequested,
+        "access_code.scheduled_on_device" => AccessCodeScheduledOnDevice,
+        "access_code.set_on_device" => AccessCodeSetOnDevice,
+        "access_code.removed_from_device" => AccessCodeRemovedFromDevice,
+        "access_code.delay_in_setting_on_device" => AccessCodeDelayInSettingOnDevice,
+        "access_code.failed_to_set_on_device" => AccessCodeFailedToSetOnDevice,
+        "access_code.deleted" => AccessCodeDeleted,
+        "access_code.delay_in_removing_from_device" => AccessCodeDelayInRemovingFromDevice,
+        "access_code.failed_to_remove_from_device" => AccessCodeFailedToRemoveFromDevice,
+        "access_code.modified_external_to_seam" => AccessCodeModifiedExternalToSeam,
+        "access_code.deleted_external_to_seam" => AccessCodeDeletedExternalToSeam,
+        "access_code.backup_access_code_pulled" => AccessCodeBackupAccessCodePulled,
+        "access_code.unmanaged.converted_to_managed" => AccessCodeUnmanagedConvertedToManaged,
+        "access_code.unmanaged.failed_to_convert_to_managed" => AccessCodeUnmanagedFailedToConvertToManaged,
+        "access_code.unmanaged.created" => AccessCodeUnmanagedCreated,
+        "access_code.unmanaged.removed" => AccessCodeUnmanagedRemoved,
+        "access_grant.created" => AccessGrantCreated,
+        "access_grant.deleted" => AccessGrantDeleted,
+        "access_grant.access_granted_to_all_doors" => AccessGrantAccessGrantedToAllDoors,
+        "access_grant.access_granted_to_door" => AccessGrantAccessGrantedToDoor,
+        "access_grant.access_to_door_lost" => AccessGrantAccessToDoorLost,
+        "access_grant.access_times_changed" => AccessGrantAccessTimesChanged,
+        "access_grant.could_not_create_requested_access_methods" => AccessGrantCouldNotCreateRequestedAccessMethods,
+        "access_method.issued" => AccessMethodIssued,
+        "access_method.revoked" => AccessMethodRevoked,
+        "access_method.card_encoding_required" => AccessMethodCardEncodingRequired,
+        "access_method.deleted" => AccessMethodDeleted,
+        "access_method.reissued" => AccessMethodReissued,
+        "access_method.created" => AccessMethodCreated,
+        "access_method.delay_in_issuing" => AccessMethodDelayInIssuing,
+        "access_method.failed_to_issue" => AccessMethodFailedToIssue,
+        "acs_system.connected" => AcsSystemConnected,
+        "acs_system.added" => AcsSystemAdded,
+        "acs_system.disconnected" => AcsSystemDisconnected,
+        "acs_credential.deleted" => AcsCredentialDeleted,
+        "acs_credential.issued" => AcsCredentialIssued,
+        "acs_credential.reissued" => AcsCredentialReissued,
+        "acs_credential.invalidated" => AcsCredentialInvalidated,
+        "acs_user.created" => AcsUserCreated,
+        "acs_user.deleted" => AcsUserDeleted,
+        "acs_encoder.added" => AcsEncoderAdded,
+        "acs_encoder.removed" => AcsEncoderRemoved,
+        "acs_access_group.deleted" => AcsAccessGroupDeleted,
+        "acs_entrance.added" => AcsEntranceAdded,
+        "acs_entrance.removed" => AcsEntranceRemoved,
+        "client_session.deleted" => ClientSessionDeleted,
+        "connected_account.connected" => ConnectedAccountConnected,
+        "connected_account.created" => ConnectedAccountCreated,
+        "connected_account.successful_login" => ConnectedAccountSuccessfulLogin,
+        "connected_account.disconnected" => ConnectedAccountDisconnected,
+        "connected_account.completed_first_sync" => ConnectedAccountCompletedFirstSync,
+        "connected_account.deleted" => ConnectedAccountDeleted,
+        "connected_account.completed_first_sync_after_reconnection" => ConnectedAccountCompletedFirstSyncAfterReconnection,
+        "connected_account.reauthorization_requested" => ConnectedAccountReauthorizationRequested,
+        "action_attempt.lock_door.succeeded" => ActionAttemptLockDoorSucceeded,
+        "action_attempt.lock_door.failed" => ActionAttemptLockDoorFailed,
+        "action_attempt.unlock_door.succeeded" => ActionAttemptUnlockDoorSucceeded,
+        "action_attempt.unlock_door.failed" => ActionAttemptUnlockDoorFailed,
+        "action_attempt.simulate_keypad_code_entry.succeeded" => ActionAttemptSimulateKeypadCodeEntrySucceeded,
+        "action_attempt.simulate_keypad_code_entry.failed" => ActionAttemptSimulateKeypadCodeEntryFailed,
+        "action_attempt.simulate_manual_lock_via_keypad.succeeded" => ActionAttemptSimulateManualLockViaKeypadSucceeded,
+        "action_attempt.simulate_manual_lock_via_keypad.failed" => ActionAttemptSimulateManualLockViaKeypadFailed,
+        "connect_webview.login_succeeded" => ConnectWebviewLoginSucceeded,
+        "connect_webview.login_failed" => ConnectWebviewLoginFailed,
+        "device.connected" => DeviceConnected,
+        "device.added" => DeviceAdded,
+        "device.converted_to_unmanaged" => DeviceConvertedToUnmanaged,
+        "device.unmanaged.converted_to_managed" => DeviceUnmanagedConvertedToManaged,
+        "device.unmanaged.connected" => DeviceUnmanagedConnected,
+        "device.disconnected" => DeviceDisconnected,
+        "device.unmanaged.disconnected" => DeviceUnmanagedDisconnected,
+        "device.tampered" => DeviceTampered,
+        "device.low_battery" => DeviceLowBattery,
+        "device.battery_status_changed" => DeviceBatteryStatusChanged,
+        "device.removed" => DeviceRemoved,
+        "device.deleted" => DeviceDeleted,
+        "device.third_party_integration_detected" => DeviceThirdPartyIntegrationDetected,
+        "device.third_party_integration_no_longer_detected" => DeviceThirdPartyIntegrationNoLongerDetected,
+        "device.salto.privacy_mode_activated" => DeviceSaltoPrivacyModeActivated,
+        "device.salto.privacy_mode_deactivated" => DeviceSaltoPrivacyModeDeactivated,
+        "device.connection_became_flaky" => DeviceConnectionBecameFlaky,
+        "device.connection_stabilized" => DeviceConnectionStabilized,
+        "device.error.subscription_required" => DeviceErrorSubscriptionRequired,
+        "device.error.subscription_required.resolved" => DeviceErrorSubscriptionRequiredResolved,
+        "device.accessory_keypad_connected" => DeviceAccessoryKeypadConnected,
+        "device.accessory_keypad_disconnected" => DeviceAccessoryKeypadDisconnected,
+        "noise_sensor.noise_threshold_triggered" => NoiseSensorNoiseThresholdTriggered,
+        "lock.locked" => LockLocked,
+        "lock.unlocked" => LockUnlocked,
+        "lock.access_denied" => LockAccessDenied,
+        "thermostat.climate_preset_activated" => ThermostatClimatePresetActivated,
+        "thermostat.manually_adjusted" => ThermostatManuallyAdjusted,
+        "thermostat.temperature_threshold_exceeded" => ThermostatTemperatureThresholdExceeded,
+        "thermostat.temperature_threshold_no_longer_exceeded" => ThermostatTemperatureThresholdNoLongerExceeded,
+        "thermostat.temperature_reached_set_point" => ThermostatTemperatureReachedSetPoint,
+        "thermostat.temperature_changed" => ThermostatTemperatureChanged,
+        "device.name_changed" => DeviceNameChanged,
+        "camera.activated" => CameraActivated,
+        "device.doorbell_rang" => DeviceDoorbellRang,
+        "phone.deactivated" => PhoneDeactivated,
+        "space.device_membership_changed" => SpaceDeviceMembershipChanged,
+        "space.created" => SpaceCreated,
+        "space.deleted" => SpaceDeleted
+      }.freeze
     end
   end
 end

--- a/lib/seam/resources/phone.rb
+++ b/lib/seam/resources/phone.rb
@@ -78,6 +78,9 @@ module Seam
       attr_accessor :device_id
       # Type of the phone device, such as `ios_phone` or `android_phone`.
       # @return [String]
+      # Known values:
+      # - `ios_phone`
+      # - `android_phone`
       attr_accessor :device_type
       # Display name of the phone. Defaults to `nickname` (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the phone easily, especially when there are numerous phones.
       # @return [String]

--- a/lib/seam/resources/unmanaged_access_code.rb
+++ b/lib/seam/resources/unmanaged_access_code.rb
@@ -41,80 +41,708 @@ module Seam
         attr_accessor :user_level_name
       end
 
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
-        class ModifiedFields < BaseResource
-          # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+        # Indicates a provider-specific issue that prevents the access code from being set or managed. Check the error message for details.
+        class ProviderIssue < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
           # @return [String]
-          attr_accessor :field
-          # The previous value of the field.
-          # @return [String, nil]
-          attr_accessor :from
-          # The new value of the field.
-          # @return [String, nil]
-          attr_accessor :to
+          # Known values:
+          # - `provider_issue`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
         end
 
-        # List of fields that were changed externally, with their previous and new values.
-        # @return [Array<ModifiedFields>]
-        resource_list_accessor :modified_fields, ModifiedFields
-        # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
-        # @return [String, nil]
-        attr_accessor :change_type
+        # Failed to set code on device.
+        class FailedToSetOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_set_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Failed to remove code from device.
+        class FailedToRemoveFromDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_remove_from_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Duplicate access code detected on device.
+        class DuplicateCodeOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `duplicate_code_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+          # @return [String, nil]
+          attr_accessor :managed_access_code_id
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+          # @return [String, nil]
+          attr_accessor :unmanaged_access_code_id
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # No space for access code on device.
+        class NoSpaceForAccessCodeOnDevice < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `no_space_for_access_code_on_device`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Code was modified or removed externally after Seam successfully set it on the device. The external change conflicts with the state that Seam is trying to apply, so Seam will attempt to set the code on the device again.
+        class ConflictingExternalModification < Errors
+          class ModifiedFields < BaseResource
+            # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            # @return [String]
+            attr_accessor :field
+            # The previous value of the field.
+            # @return [String, nil]
+            attr_accessor :from
+            # The new value of the field.
+            # @return [String, nil]
+            attr_accessor :to
+          end
+
+          # List of fields that were changed externally, with their previous and new values.
+          # @return [Array<ModifiedFields>]
+          resource_list_accessor :modified_fields, ModifiedFields
+          # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+          # @return [String, nil]
+          # Known values:
+          # - `modified`
+          # - `removed`
+          attr_accessor :change_type
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `conflicting_external_modification`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access code is disabled or inactive on the device. The code exists but will not grant access until re-enabled.
+        class AccessCodeInactive < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `access_code_inactive`
+          attr_accessor :error_code
+          # Indicates that this is an access code error.
+          # @return [TrueClass]
+          attr_accessor :is_access_code_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Indicates that the account is disconnected.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto site user limit has been reached.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam's integration user does not have sufficient permissions on the provider's system to which this device belongs, so Seam cannot manage access codes or unlock the device. See the error message for specifics, then either reauthorize the connected account in Seam or grant the integration user the required permissions in the provider's system.
+        class InsufficientPermissions < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `insufficient_permissions`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account could not be connected. Contact dormakaba support.
+        class DormakabaSitesDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is offline.
+        class DeviceOffline < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_offline`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has been removed.
+        class DeviceRemoved < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_removed`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the hub is disconnected.
+        class HubDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is disconnected.
+        class DeviceDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is empty.
+        class EmptyBackupAccessCodePool < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `empty_backup_access_code_pool`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the user is not authorized to use the August lock.
+        class AugustLockNotAuthorized < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `august_lock_not_authorized`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that device credentials are missing.
+        class MissingDeviceCredentials < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `missing_device_credentials`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the auxiliary heat is running.
+        class AuxiliaryHeatRunning < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `auxiliary_heat_running`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a subscription is required to connect.
+        class SubscriptionRequired < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `subscription_required`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `provider_issue`
+        # - `failed_to_set_on_device`
+        # - `failed_to_remove_from_device`
+        # - `duplicate_code_on_device`
+        # - `no_space_for_access_code_on_device`
+        # - `conflicting_external_modification`
+        # - `access_code_inactive`
+        # - `account_disconnected`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `insufficient_permissions`
+        # - `dormakaba_sites_disconnected`
+        # - `device_offline`
+        # - `device_removed`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        # - `empty_backup_access_code_pool`
+        # - `august_lock_not_authorized`
+        # - `missing_device_credentials`
+        # - `auxiliary_heat_running`
+        # - `subscription_required`
+        # - `bridge_disconnected`
         attr_accessor :error_code
-        # Indicates that this is an access code error.
-        # @return [TrueClass]
-        attr_accessor :is_access_code_error
-        # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
-        # @return [Boolean, nil]
-        attr_accessor :is_bridge_error
-        # @return [Boolean, nil]
-        attr_accessor :is_connected_account_error
-        # @return [Boolean]
-        attr_accessor :is_device_error
-        # ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
-        # @return [String, nil]
-        attr_accessor :managed_access_code_id
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
-        # @return [String, nil]
-        attr_accessor :unmanaged_access_code_id
         # Date and time at which Seam created the error.
         # @return [Time, nil]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "provider_issue" => ProviderIssue,
+          "failed_to_set_on_device" => FailedToSetOnDevice,
+          "failed_to_remove_from_device" => FailedToRemoveFromDevice,
+          "duplicate_code_on_device" => DuplicateCodeOnDevice,
+          "no_space_for_access_code_on_device" => NoSpaceForAccessCodeOnDevice,
+          "conflicting_external_modification" => ConflictingExternalModification,
+          "access_code_inactive" => AccessCodeInactive,
+          "account_disconnected" => AccountDisconnected,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "insufficient_permissions" => InsufficientPermissions,
+          "dormakaba_sites_disconnected" => DormakabaSitesDisconnected,
+          "device_offline" => DeviceOffline,
+          "device_removed" => DeviceRemoved,
+          "hub_disconnected" => HubDisconnected,
+          "device_disconnected" => DeviceDisconnected,
+          "empty_backup_access_code_pool" => EmptyBackupAccessCodePool,
+          "august_lock_not_authorized" => AugustLockNotAuthorized,
+          "missing_device_credentials" => MissingDeviceCredentials,
+          "auxiliary_heat_running" => AuxiliaryHeatRunning,
+          "subscription_required" => SubscriptionRequired,
+          "bridge_disconnected" => BridgeDisconnected
+        }.freeze
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        class ModifiedFields < BaseResource
-          # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+        # The access code's PIN rotates periodically when the code is renewed. Retrieve the latest code before each use.
+        class CodeRotatesPeriodically < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
-          attr_accessor :field
-          # The previous value of the field.
-          # @return [String, nil]
-          attr_accessor :from
-          # The new value of the field.
-          # @return [String, nil]
-          attr_accessor :to
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `code_rotates_periodically`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
         end
 
-        # List of fields that were changed externally, with their previous and new values.
-        # @return [Array<ModifiedFields>]
-        resource_list_accessor :modified_fields, ModifiedFields
-        # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
-        # @return [String, nil]
-        attr_accessor :change_type
+        # The device's time zone is unknown and this code's time frame crosses a daylight-saving transition in at least one plausible time zone. A 1-hour safety buffer has been applied to the side of the time frame affected by the transition (`ends_at` for spring-forward, `starts_at` for fall-back) so the code stays active through the shift — the code may be usable up to 1 hour beyond your requested window. Set the device's time zone via `/devices/report_provider_metadata` to clear the buffer and guarantee exact handling.
+        class TimeFrameAdjustedForUnknownTimeZone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_frame_adjusted_for_unknown_time_zone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Code was modified or removed externally after Seam successfully set it on the device. External modification is allowed for this code, so the externally modified state is being honored.
+        class ExternalModificationInEffect < Warnings
+          class ModifiedFields < BaseResource
+            # The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            # @return [String]
+            attr_accessor :field
+            # The previous value of the field.
+            # @return [String, nil]
+            attr_accessor :from
+            # The new value of the field.
+            # @return [String, nil]
+            attr_accessor :to
+          end
+
+          # List of fields that were changed externally, with their previous and new values.
+          # @return [Array<ModifiedFields>]
+          resource_list_accessor :modified_fields, ModifiedFields
+          # Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+          # @return [String, nil]
+          # Known values:
+          # - `modified`
+          # - `removed`
+          attr_accessor :change_type
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `external_modification_in_effect`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Delay in setting code on device.
+        class DelayInSettingOnDevice < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_setting_on_device`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Delay in removing code from device.
+        class DelayInRemovingFromDevice < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_removing_from_device`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Third-party integration detected that may cause access codes to fail.
+        class ThirdPartyIntegrationDetected < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `third_party_integration_detected`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Algopins must be used within 24 hours.
+        class IglooAlgopinMustBeUsedWithinN24Hours < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `igloo_algopin_must_be_used_within_24_hours`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Management was transferred to another workspace.
+        class ManagementTransferred < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `management_transferred`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # A backup access code has been pulled and is being used in place of this access code.
+        class UsingBackupAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `using_backup_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # Access code is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
+        # An unknown issue occurred with the access code.
+        class UnknownIssueWithAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time, nil]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `code_rotates_periodically`
+        # - `time_frame_adjusted_for_unknown_time_zone`
+        # - `external_modification_in_effect`
+        # - `delay_in_setting_on_device`
+        # - `delay_in_removing_from_device`
+        # - `third_party_integration_detected`
+        # - `igloo_algopin_must_be_used_within_24_hours`
+        # - `management_transferred`
+        # - `using_backup_access_code`
+        # - `being_deleted`
+        # - `unknown_issue_with_access_code`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time, nil]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "code_rotates_periodically" => CodeRotatesPeriodically,
+          "time_frame_adjusted_for_unknown_time_zone" => TimeFrameAdjustedForUnknownTimeZone,
+          "external_modification_in_effect" => ExternalModificationInEffect,
+          "delay_in_setting_on_device" => DelayInSettingOnDevice,
+          "delay_in_removing_from_device" => DelayInRemovingFromDevice,
+          "third_party_integration_detected" => ThirdPartyIntegrationDetected,
+          "igloo_algopin_must_be_used_within_24_hours" => IglooAlgopinMustBeUsedWithinN24Hours,
+          "management_transferred" => ManagementTransferred,
+          "using_backup_access_code" => UsingBackupAccessCode,
+          "being_deleted" => BeingDeleted,
+          "unknown_issue_with_access_code" => UnknownIssueWithAccessCode
+        }.freeze
       end
 
       # Metadata for a dormakaba Oracode unmanaged access code. Only present for unmanaged access codes from dormakaba Oracode devices.
@@ -149,9 +777,15 @@ module Seam
       attr_accessor :name
       # Current status of the access code within the operational lifecycle. `set` indicates that the code is active and operational. `unset` indicates that the code exists on the provider but is not usable on the device.
       # @return [String]
+      # Known values:
+      # - `set`
+      # - `unset`
       attr_accessor :status
       # Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
       # @return [String]
+      # Known values:
+      # - `time_bound`
+      # - `ongoing`
       attr_accessor :type
       # Unique identifier for the Seam workspace associated with the access code.
       # @return [String]

--- a/lib/seam/resources/unmanaged_access_grant.rb
+++ b/lib/seam/resources/unmanaged_access_grant.rb
@@ -4,19 +4,41 @@ module Seam
   module Resources
     # Represents an unmanaged Access Grant. Unmanaged Access Grants do not have client sessions, instant keys, customization profiles, or keys.
     class UnmanagedAccessGrant < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that Seam could not create one or more of the requested access methods for the access grant.
+        class CannotCreateRequestedAccessMethods < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `cannot_create_requested_access_methods`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
+          # @return [Array<String>]
+          attr_accessor :missing_device_ids
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `cannot_create_requested_access_methods`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
-        # @return [Array<String>]
-        attr_accessor :missing_device_ids
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "cannot_create_requested_access_methods" => CannotCreateRequestedAccessMethods
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -58,6 +80,8 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `updating_spaces`
         attr_accessor :mutation_code
         # Date and time at which the mutation was created.
         # @return [Time]
@@ -79,51 +103,191 @@ module Seam
         attr_accessor :instant_key_max_use_count
         # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
         # @return [String]
+        # Known values:
+        # - `code`
+        # - `card`
+        # - `mobile_key`
+        # - `cloud_key`
         attr_accessor :mode
         # Date and time at which the requested access method was added to the Access Grant.
         # @return [Time]
         date_accessor :created_at
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        class FailedDevices < BaseResource
-          # Device whose access code could not be revoked.
-          # @return [String]
-          attr_accessor :device_id
-          # Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
-          # @return [String]
-          attr_accessor :error_code
-          # Human-readable description of why revocation failed.
+        # Indicates that the [access grant](https://docs.seam.co/use-cases/granting-access) is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
           # @return [String]
           attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
         end
 
-        # Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
-        # @return [Array<FailedDevices>]
-        resource_list_accessor :failed_devices, FailedDevices
-        # IDs of the access methods being updated.
-        # @return [Array<String>]
-        attr_accessor :access_method_ids
-        # @return [String]
-        attr_accessor :device_id
+        # Indicates that the access grant should have access to more locations than it currently does. Access methods are being created for the missing locations.
+        class UnderprovisionedAccess < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `underprovisioned_access`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access grant has access to locations it should not have. Access methods are being removed from the extra locations.
+        class OverprovisionedAccess < Warnings
+          class FailedDevices < BaseResource
+            # Device whose access code could not be revoked.
+            # @return [String]
+            attr_accessor :device_id
+            # Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
+            # @return [String]
+            attr_accessor :error_code
+            # Human-readable description of why revocation failed.
+            # @return [String]
+            attr_accessor :message
+          end
+
+          # Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+          # @return [Array<FailedDevices>]
+          resource_list_accessor :failed_devices, FailedDevices
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `overprovisioned_access`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access times for this [access grant](https://docs.seam.co/use-cases/granting-access) are being updated.
+        class UpdatingAccessTimes < Warnings
+          # IDs of the access methods being updated.
+          # @return [Array<String>]
+          attr_accessor :access_method_ids
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `updating_access_times`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the requested PIN code was already in use on a device, so a different code was assigned.
+        class RequestedCodeUnavailable < Warnings
+          # ID of the device where the requested code was unavailable.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # The new PIN code that was assigned instead.
+          # @return [String]
+          attr_accessor :new_code
+          # The originally requested PIN code that was unavailable.
+          # @return [String]
+          attr_accessor :original_code
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `requested_code_unavailable`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a device in the access grant does not support access codes and was excluded from code materialization.
+        class DeviceDoesNotSupportAccessCodes < Warnings
+          # ID of the device that does not support access codes.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_does_not_support_access_codes`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a device in the access grant cannot program an access code for the grant's time range because of device-specific time constraints.
+        class DeviceTimeConstraintsViolated < Warnings
+          # ID of the device whose time constraints the access grant violates.
+          # @return [String]
+          attr_accessor :device_id
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Specific reason why the grant's times are not programmable on the device.
+          # @return [String]
+          # Known values:
+          # - `duration_exceeds_max`
+          # - `times_do_not_match_slots`
+          # - `ongoing_not_supported`
+          attr_accessor :reason
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_time_constraints_violated`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # The new PIN code that was assigned instead.
-        # @return [String]
-        attr_accessor :new_code
-        # The originally requested PIN code that was unavailable.
-        # @return [String]
-        attr_accessor :original_code
-        # Specific reason why the grant's times are not programmable on the device.
-        # @return [String]
-        attr_accessor :reason
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `underprovisioned_access`
+        # - `overprovisioned_access`
+        # - `updating_access_times`
+        # - `requested_code_unavailable`
+        # - `device_does_not_support_access_codes`
+        # - `device_time_constraints_violated`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "underprovisioned_access" => UnderprovisionedAccess,
+          "overprovisioned_access" => OverprovisionedAccess,
+          "updating_access_times" => UpdatingAccessTimes,
+          "requested_code_unavailable" => RequestedCodeUnavailable,
+          "device_does_not_support_access_codes" => DeviceDoesNotSupportAccessCodes,
+          "device_time_constraints_violated" => DeviceTimeConstraintsViolated
+        }.freeze
       end
 
       # Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).

--- a/lib/seam/resources/unmanaged_access_method.rb
+++ b/lib/seam/resources/unmanaged_access_method.rb
@@ -4,9 +4,27 @@ module Seam
   module Resources
     # Represents an unmanaged access method. Unmanaged access methods do not have client sessions, instant keys, customization profiles, or keys.
     class UnmanagedAccessMethod < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that Seam was unable to issue this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) before its access grant started, so the recipient may be unable to access the space. This usually points to a problem that needs attention, such as an offline or disconnected device. Seam keeps retrying, and this error clears automatically if the access method is eventually issued.
+        class FailedToIssue < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `failed_to_issue`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `failed_to_issue`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -14,6 +32,10 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "failed_to_issue" => FailedToIssue
+        }.freeze
       end
 
       class PendingMutations < BaseResource
@@ -47,25 +69,100 @@ module Seam
         # @return [String]
         attr_accessor :message
         # @return [String]
+        # Known values:
+        # - `provisioning_access`
         attr_accessor :mutation_code
         # Date and time at which the mutation was created.
         # @return [Time]
         date_accessor :created_at
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) is being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the access times for this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant) are being updated.
+        class UpdatingAccessTimes < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `updating_access_times`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that all attempts to create an access code on this device before the start time failed and a backup access code was used to ensure access was provided in time.
+        class PulledBackupAccessCode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # ID of the original access method from which this backup access method was split, if applicable.
+          # @return [String, nil]
+          attr_accessor :original_access_method_id
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `pulled_backup_access_code`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam has not yet issued this [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant), even though its access grant is about to begin, so access may not be ready when the recipient arrives. Seam is still attempting to issue it, and this warning clears automatically once issuance succeeds.
+        class DelayInIssuing < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `delay_in_issuing`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
-        # ID of the original access method from which this backup access method was split, if applicable.
-        # @return [String, nil]
-        attr_accessor :original_access_method_id
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `updating_access_times`
+        # - `pulled_backup_access_code`
+        # - `delay_in_issuing`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "updating_access_times" => UpdatingAccessTimes,
+          "pulled_backup_access_code" => PulledBackupAccessCode,
+          "delay_in_issuing" => DelayInIssuing
+        }.freeze
       end
 
       # Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
@@ -103,6 +200,11 @@ module Seam
       attr_accessor :is_ready_for_encoding
       # Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
       # @return [String]
+      # Known values:
+      # - `code`
+      # - `card`
+      # - `mobile_key`
+      # - `cloud_key`
       attr_accessor :mode
       # ID of the Seam workspace associated with the access method.
       # @return [String]

--- a/lib/seam/resources/unmanaged_device.rb
+++ b/lib/seam/resources/unmanaged_device.rb
@@ -4,23 +4,316 @@ module Seam
   module Resources
     # Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
     class UnmanagedDevice < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that the account is disconnected.
+        class AccountDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `account_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto site user limit has been reached.
+        class SaltoKsSubscriptionLimitExceeded < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_exceeded`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam's integration user does not have sufficient permissions on the provider's system to which this device belongs, so Seam cannot manage access codes or unlock the device. See the error message for specifics, then either reauthorize the connected account in Seam or grant the integration user the required permissions in the provider's system.
+        class InsufficientPermissions < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `insufficient_permissions`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that one or more dormakaba sites associated with the connected account could not be connected. Contact dormakaba support.
+        class DormakabaSitesDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `dormakaba_sites_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+          # @return [TrueClass]
+          attr_accessor :is_connected_account_error
+          # Indicates that the error is not a device error.
+          # @return [FalseClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is offline.
+        class DeviceOffline < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_offline`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has been removed.
+        class DeviceRemoved < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_removed`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the hub is disconnected.
+        class HubDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is disconnected.
+        class DeviceDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_disconnected`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is empty.
+        class EmptyBackupAccessCodePool < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `empty_backup_access_code_pool`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the user is not authorized to use the August lock.
+        class AugustLockNotAuthorized < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `august_lock_not_authorized`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that device credentials are missing.
+        class MissingDeviceCredentials < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `missing_device_credentials`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the auxiliary heat is running.
+        class AuxiliaryHeatRunning < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `auxiliary_heat_running`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a subscription is required to connect.
+        class SubscriptionRequired < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `subscription_required`
+          attr_accessor :error_code
+          # Indicates that the error is a device error.
+          # @return [TrueClass]
+          attr_accessor :is_device_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/low-level-apis/access-systems/troubleshooting-your-access-control-system#acs_system-errors-seam_bridge_disconnected).
+        class BridgeDisconnected < Errors
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `bridge_disconnected`
+          attr_accessor :error_code
+          # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+          # @return [Boolean, nil]
+          attr_accessor :is_bridge_error
+          # Indicates whether the error is related specifically to the connected account.
+          # @return [Boolean, nil]
+          attr_accessor :is_connected_account_error
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `account_disconnected`
+        # - `salto_ks_subscription_limit_exceeded`
+        # - `insufficient_permissions`
+        # - `dormakaba_sites_disconnected`
+        # - `device_offline`
+        # - `device_removed`
+        # - `hub_disconnected`
+        # - `device_disconnected`
+        # - `empty_backup_access_code_pool`
+        # - `august_lock_not_authorized`
+        # - `missing_device_credentials`
+        # - `auxiliary_heat_running`
+        # - `subscription_required`
+        # - `bridge_disconnected`
         attr_accessor :error_code
-        # Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
-        # @return [Boolean, nil]
-        attr_accessor :is_bridge_error
-        # @return [Boolean, nil]
-        attr_accessor :is_connected_account_error
-        # @return [Boolean]
-        attr_accessor :is_device_error
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "account_disconnected" => AccountDisconnected,
+          "salto_ks_subscription_limit_exceeded" => SaltoKsSubscriptionLimitExceeded,
+          "insufficient_permissions" => InsufficientPermissions,
+          "dormakaba_sites_disconnected" => DormakabaSitesDisconnected,
+          "device_offline" => DeviceOffline,
+          "device_removed" => DeviceRemoved,
+          "hub_disconnected" => HubDisconnected,
+          "device_disconnected" => DeviceDisconnected,
+          "empty_backup_access_code_pool" => EmptyBackupAccessCodePool,
+          "august_lock_not_authorized" => AugustLockNotAuthorized,
+          "missing_device_credentials" => MissingDeviceCredentials,
+          "auxiliary_heat_running" => AuxiliaryHeatRunning,
+          "subscription_required" => SubscriptionRequired,
+          "bridge_disconnected" => BridgeDisconnected
+        }.freeze
       end
 
       class Location < BaseResource
@@ -60,6 +353,11 @@ module Seam
           attr_accessor :level
           # Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
           # @return [String]
+          # Known values:
+          # - `critical`
+          # - `low`
+          # - `good`
+          # - `full`
           attr_accessor :status
         end
 
@@ -125,22 +423,486 @@ module Seam
         attr_accessor :online_access_codes_enabled
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
-        # Number of active access codes on the device when the warning was set.
-        # @return [Integer]
-        attr_accessor :active_access_code_count
-        # Maximum number of active access codes supported by the device.
-        # @return [Integer]
-        attr_accessor :max_active_access_code_count
+        # Indicates that the backup access code is unhealthy.
+        class PartialBackupAccessCodePool < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `partial_backup_access_code_pool`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that there are too many backup codes.
+        class ManyActiveBackupCodes < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `many_active_backup_codes`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a third-party integration has been detected.
+        class ThirdPartyIntegrationDetected < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `third_party_integration_detected`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Remote Unlock feature is not enabled in the settings."
+        class TtlockLockGatewayUnlockingNotEnabled < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ttlock_lock_gateway_unlocking_not_enabled`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the gateway signal is weak.
+        class TtlockWeakGatewaySignal < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ttlock_weak_gateway_signal`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device is in power saving mode and may have limited functionality.
+        class PowerSavingMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `power_saving_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the temperature threshold has been exceeded.
+        class TemperatureThresholdExceeded < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `temperature_threshold_exceeded`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device appears to be unresponsive.
+        class DeviceCommunicationDegraded < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_communication_degraded`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a scheduled maintenance window has been detected.
+        class ScheduledMaintenanceWindow < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `scheduled_maintenance_window`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has a flaky connection.
+        class DeviceHasFlakyConnection < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `device_has_flaky_connection`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS lock is in Office Mode. Access Codes will not unlock doors.
+        class SaltoKsOfficeMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_office_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS lock is in Privacy Mode. Access Codes will not unlock doors.
+        class SaltoKsPrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the lock is in Privacy Mode. Access codes and remote unlock are blocked until Privacy Mode is disabled.
+        class PrivacyMode < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `privacy_mode`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the Salto KS site has exceeded 80% of the maximum number of allowed users. Increase your subscription limit or delete some users from your site.
+        class SaltoKsSubscriptionLimitAlmostReached < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_subscription_limit_almost_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a change in the reported device model has been detected for this Salto KS lock, which may occur after an IQ hub reset. Access code support may be affected. See https://help.getseam.com/articles/5098842588-salto-ks-lock-loses-access-code-support for troubleshooting steps.
+        class SaltoKsLockAccessCodeSupportRemoved < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `salto_ks_lock_access_code_support_removed`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that an unknown issue occurred while syncing the state of the phone with the provider. This issue may affect the proper functioning of the phone.
+        class UnknownIssueWithPhone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unknown_issue_with_phone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam detected that the Lockly device does not have a time zone configured. Time-bound codes may not work as expected.
+        class LocklyTimeZoneNotConfigured < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `lockly_time_zone_not_configured`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam does not know the time zone of the Ultraloq device. Set a time zone to enable time-bound access codes.
+        class UltraloqTimeZoneUnknown < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `ultraloq_time_zone_unknown`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that Seam does not know the device's time zone. Set a time zone to enable time-bound access codes.
+        class TimeZoneUnknown < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_zone_unknown`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device's configured time zone does not match its hardware UTC offset. Time-bound access codes may activate at the wrong local time.
+        class TimeZoneMismatch < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `time_zone_mismatch`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the 2N device does not have a time zone configured. Configure a time zone on the device to enable access codes.
+        class TwoNDeviceMissingTimezone < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `two_n_device_missing_timezone`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that a hub or relay must be connected to unlock additional capabilities such as remote unlock.
+        class HubRequiredForAdditionalCapabilities < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `hub_required_for_additional_capabilities`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates a provider-specific issue that may affect device functionality.
+        class ProviderIssue < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `provider_issue`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the key is in a locker that does not support the access codes API.
+        class KeynestUnsupportedLocker < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `keynest_unsupported_locker`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the accessory keypad exists, but is not linked to the Igloohome Bridge. Online access code programming will fail until the keypad is linked to the Igloohome Bridge in the Igloohome app.
+        class AccessoryKeypadSetupRequired < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `accessory_keypad_setup_required`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device may optimistically be reported as online because the provider does not reliably report its online status.
+        class UnreliableOnlineStatus < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `unreliable_online_status`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the device has reached its maximum number of active access codes. Delete existing codes before creating new ones.
+        class MaxAccessCodesReached < Warnings
+          # Number of active access codes on the device when the warning was set.
+          # @return [Integer]
+          attr_accessor :active_access_code_count
+          # Maximum number of active access codes supported by the device.
+          # @return [Integer]
+          attr_accessor :max_active_access_code_count
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `max_access_codes_reached`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `partial_backup_access_code_pool`
+        # - `many_active_backup_codes`
+        # - `third_party_integration_detected`
+        # - `ttlock_lock_gateway_unlocking_not_enabled`
+        # - `ttlock_weak_gateway_signal`
+        # - `power_saving_mode`
+        # - `temperature_threshold_exceeded`
+        # - `device_communication_degraded`
+        # - `scheduled_maintenance_window`
+        # - `device_has_flaky_connection`
+        # - `salto_ks_office_mode`
+        # - `salto_ks_privacy_mode`
+        # - `privacy_mode`
+        # - `salto_ks_subscription_limit_almost_reached`
+        # - `salto_ks_lock_access_code_support_removed`
+        # - `unknown_issue_with_phone`
+        # - `lockly_time_zone_not_configured`
+        # - `ultraloq_time_zone_unknown`
+        # - `time_zone_unknown`
+        # - `time_zone_mismatch`
+        # - `two_n_device_missing_timezone`
+        # - `hub_required_for_additional_capabilities`
+        # - `provider_issue`
+        # - `keynest_unsupported_locker`
+        # - `accessory_keypad_setup_required`
+        # - `unreliable_online_status`
+        # - `max_access_codes_reached`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "partial_backup_access_code_pool" => PartialBackupAccessCodePool,
+          "many_active_backup_codes" => ManyActiveBackupCodes,
+          "third_party_integration_detected" => ThirdPartyIntegrationDetected,
+          "ttlock_lock_gateway_unlocking_not_enabled" => TtlockLockGatewayUnlockingNotEnabled,
+          "ttlock_weak_gateway_signal" => TtlockWeakGatewaySignal,
+          "power_saving_mode" => PowerSavingMode,
+          "temperature_threshold_exceeded" => TemperatureThresholdExceeded,
+          "device_communication_degraded" => DeviceCommunicationDegraded,
+          "scheduled_maintenance_window" => ScheduledMaintenanceWindow,
+          "device_has_flaky_connection" => DeviceHasFlakyConnection,
+          "salto_ks_office_mode" => SaltoKsOfficeMode,
+          "salto_ks_privacy_mode" => SaltoKsPrivacyMode,
+          "privacy_mode" => PrivacyMode,
+          "salto_ks_subscription_limit_almost_reached" => SaltoKsSubscriptionLimitAlmostReached,
+          "salto_ks_lock_access_code_support_removed" => SaltoKsLockAccessCodeSupportRemoved,
+          "unknown_issue_with_phone" => UnknownIssueWithPhone,
+          "lockly_time_zone_not_configured" => LocklyTimeZoneNotConfigured,
+          "ultraloq_time_zone_unknown" => UltraloqTimeZoneUnknown,
+          "time_zone_unknown" => TimeZoneUnknown,
+          "time_zone_mismatch" => TimeZoneMismatch,
+          "two_n_device_missing_timezone" => TwoNDeviceMissingTimezone,
+          "hub_required_for_additional_capabilities" => HubRequiredForAdditionalCapabilities,
+          "provider_issue" => ProviderIssue,
+          "keynest_unsupported_locker" => KeynestUnsupportedLocker,
+          "accessory_keypad_setup_required" => AccessoryKeypadSetupRequired,
+          "unreliable_online_status" => UnreliableOnlineStatus,
+          "max_access_codes_reached" => MaxAccessCodesReached
+        }.freeze
       end
 
       # Location information for the device.
@@ -217,6 +979,13 @@ module Seam
       attr_accessor :can_unlock_with_code
       # Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
       # @return [Array<String>]
+      # Known values:
+      # - `access_code`
+      # - `lock`
+      # - `noise_detection`
+      # - `thermostat`
+      # - `battery`
+      # - `phone`
       attr_accessor :capabilities_supported
       # Unique identifier for the account associated with the device.
       # @return [String]
@@ -229,6 +998,50 @@ module Seam
       attr_accessor :device_id
       # Type of the device.
       # @return [String]
+      # Known values:
+      # - `akuvox_lock`
+      # - `august_lock`
+      # - `brivo_access_point`
+      # - `butterflymx_panel`
+      # - `avigilon_alta_entry`
+      # - `doorking_lock`
+      # - `genie_door`
+      # - `igloo_lock`
+      # - `linear_lock`
+      # - `lockly_lock`
+      # - `kwikset_lock`
+      # - `nuki_lock`
+      # - `salto_lock`
+      # - `schlage_lock`
+      # - `smartthings_lock`
+      # - `wyze_lock`
+      # - `yale_lock`
+      # - `two_n_intercom`
+      # - `controlbyweb_device`
+      # - `ttlock_lock`
+      # - `igloohome_lock`
+      # - `four_suites_door`
+      # - `dormakaba_oracode_door`
+      # - `tedee_lock`
+      # - `akiles_lock`
+      # - `ultraloq_lock`
+      # - `yacan_lock`
+      # - `keyincode_lock`
+      # - `omnitec_lock`
+      # - `kisi_lock`
+      # - `aqara_lock`
+      # - `keynest_key`
+      # - `noiseaware_activity_zone`
+      # - `minut_sensor`
+      # - `ecobee_thermostat`
+      # - `nest_thermostat`
+      # - `honeywell_resideo_thermostat`
+      # - `tado_thermostat`
+      # - `sensi_thermostat`
+      # - `smartthings_thermostat`
+      # - `ios_phone`
+      # - `android_phone`
+      # - `ring_camera`
       attr_accessor :device_type
       # Indicates that Seam does not manage the device.
       # @return [FalseClass]

--- a/lib/seam/resources/unmanaged_user_identity.rb
+++ b/lib/seam/resources/unmanaged_user_identity.rb
@@ -4,7 +4,29 @@ module Seam
   module Resources
     # Represents an unmanaged user identity. Unmanaged user identities do not have keys.
     class UnmanagedUserIdentity < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that there is an issue with an access system user associated with this user identity.
+        class IssueWithAcsUser < Errors
+          # ID of the access system that the user identity is associated with.
+          # @return [String]
+          attr_accessor :acs_system_id
+          # ID of the access system user that has an issue.
+          # @return [String]
+          attr_accessor :acs_user_id
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `issue_with_acs_user`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # ID of the access system that the user identity is associated with.
         # @return [String]
         attr_accessor :acs_system_id
@@ -13,6 +35,8 @@ module Seam
         attr_accessor :acs_user_id
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `issue_with_acs_user`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -20,18 +44,61 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "issue_with_acs_user" => IssueWithAcsUser
+        }.freeze
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the user identity is currently being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the ACS user's profile does not match the user identity's profile
+        class AcsUserProfileDoesNotMatchUserIdentity < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `acs_user_profile_does_not_match_user_identity`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `acs_user_profile_does_not_match_user_identity`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "acs_user_profile_does_not_match_user_identity" => AcsUserProfileDoesNotMatchUserIdentity
+        }.freeze
       end
 
       # Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.

--- a/lib/seam/resources/user_identity.rb
+++ b/lib/seam/resources/user_identity.rb
@@ -4,7 +4,29 @@ module Seam
   module Resources
     # Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
     class UserIdentity < BaseResource
+      # Known `error_code` values load as subclasses; unknown values remain Errors instances for forward compatibility.
       class Errors < BaseResource
+        # Indicates that there is an issue with an access system user associated with this user identity.
+        class IssueWithAcsUser < Errors
+          # ID of the access system that the user identity is associated with.
+          # @return [String]
+          attr_accessor :acs_system_id
+          # ID of the access system user that has an issue.
+          # @return [String]
+          attr_accessor :acs_user_id
+          # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `issue_with_acs_user`
+          attr_accessor :error_code
+          # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Date and time at which Seam created the error.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # ID of the access system that the user identity is associated with.
         # @return [String]
         attr_accessor :acs_system_id
@@ -13,6 +35,8 @@ module Seam
         attr_accessor :acs_user_id
         # Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `issue_with_acs_user`
         attr_accessor :error_code
         # Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
@@ -20,18 +44,61 @@ module Seam
         # Date and time at which Seam created the error.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :error_code, {
+          "issue_with_acs_user" => IssueWithAcsUser
+        }.freeze
       end
 
+      # Known `warning_code` values load as subclasses; unknown values remain Warnings instances for forward compatibility.
       class Warnings < BaseResource
+        # Indicates that the user identity is currently being deleted.
+        class BeingDeleted < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `being_deleted`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
+        # Indicates that the ACS user's profile does not match the user identity's profile
+        class AcsUserProfileDoesNotMatchUserIdentity < Warnings
+          # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+          # @return [String]
+          attr_accessor :message
+          # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+          # @return [String]
+          # Known values:
+          # - `acs_user_profile_does_not_match_user_identity`
+          attr_accessor :warning_code
+          # Date and time at which Seam created the warning.
+          # @return [Time]
+          date_accessor :created_at
+        end
+
         # Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
         # @return [String]
         attr_accessor :message
         # Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
         # @return [String]
+        # Known values:
+        # - `being_deleted`
+        # - `acs_user_profile_does_not_match_user_identity`
         attr_accessor :warning_code
         # Date and time at which Seam created the warning.
         # @return [Time]
         date_accessor :created_at
+
+        discriminated_by :warning_code, {
+          "being_deleted" => BeingDeleted,
+          "acs_user_profile_does_not_match_user_identity" => AcsUserProfileDoesNotMatchUserIdentity
+        }.freeze
       end
 
       # Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.

--- a/lib/seam/resources/workspace.rb
+++ b/lib/seam/resources/workspace.rb
@@ -10,6 +10,9 @@ module Seam
         attr_accessor :inviter_logo_url
         # Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
         # @return [String, nil]
+        # Known values:
+        # - `circle`
+        # - `square`
         attr_accessor :logo_shape
         # Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
         # @return [String, nil]

--- a/lib/seam/webhook.rb
+++ b/lib/seam/webhook.rb
@@ -13,11 +13,14 @@ module Seam
       @webhook = Svix::Webhook.new(secret)
     end
 
+    # Known event types return a SeamEvent subclass; unknown types return a
+    # generic SeamEvent for forward compatibility.
+    # @return [Seam::Resources::SeamEvent]
     def verify(payload, headers)
       normalized_headers = headers.transform_keys(&:downcase)
-      res = @webhook.verify(payload, normalized_headers)
+      event_data = @webhook.verify(payload, normalized_headers)
 
-      Seam::Resources::SeamEvent.load_from_response(res)
+      Seam::Resources::SeamEvent.load_from_response(event_data)
     end
   end
 end

--- a/spec/resources/base_resource_hash_spec.rb
+++ b/spec/resources/base_resource_hash_spec.rb
@@ -57,27 +57,28 @@ RSpec.describe Seam::Resources::BaseResource do
       expect(keypad_battery).not_to be_a(Seam::Resources::Device::Properties::Battery)
     end
 
-    it "keeps every variant field when merged into one class" do
-      encoded = Seam::Resources::ActionAttempt.new(
-        action_type: "ENCODE_ACS_CREDENTIAL",
+    it "uses action-specific result classes" do
+      scanned = Seam::Resources::ActionAttempt.load_from_response(
+        action_type: "SCAN_CREDENTIAL",
         result: {
           acs_credential_on_encoder: {card_number: "123"},
           acs_credential_on_seam: {acs_credential_id: "cred_1"}
         }
       )
 
-      expect(encoded.result.acs_credential_on_encoder.card_number).to eq("123")
-      expect(encoded.result.acs_credential_on_seam.acs_credential_id).to eq("cred_1")
+      expect(scanned).to be_a(Seam::Resources::ActionAttempt::ScanCredential)
+      expect(scanned.result).to be_a(Seam::Resources::ActionAttempt::ScanCredential::Result)
+      expect(scanned.result.acs_credential_on_encoder.card_number).to eq("123")
+      expect(scanned.result.acs_credential_on_seam.acs_credential_id).to eq("cred_1")
 
-      instant_key = Seam::Resources::ActionAttempt.new(
-        action_type: "CREATE_INSTANT_KEY",
-        result: {instant_key_url: "https://example.com"}
+      created = Seam::Resources::ActionAttempt.load_from_response(
+        action_type: "CREATE_NOISE_THRESHOLD",
+        result: {noise_threshold: {noise_threshold_id: "noise_1"}}
       )
 
-      expect(instant_key.result.instant_key_url).to eq("https://example.com")
-
-      # A field from a third variant, on the same merged class.
-      expect(instant_key.result).to respond_to(:was_confirmed_by_device)
+      expect(created).to be_a(Seam::Resources::ActionAttempt::CreateNoiseThreshold)
+      expect(created.result.noise_threshold.noise_threshold_id).to eq("noise_1")
+      expect(created.result).not_to respond_to(:was_confirmed_by_device)
     end
 
     it "merges variant fields recursively into nested objects" do

--- a/spec/resources/discriminated_variants_spec.rb
+++ b/spec/resources/discriminated_variants_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe "discriminated resources" do
+  describe Seam::Resources::SeamEvent do
+    it "loads known event types as SeamEvent subclasses" do
+      event = described_class.load_from_response(
+        "event_type" => "access_code.created",
+        "access_code_id" => "access_code_1"
+      )
+
+      expect(event).to be_a(described_class)
+      expect(event).to be_a(described_class::AccessCodeCreated)
+      expect(event.access_code_id).to eq("access_code_1")
+      expect(event).not_to respond_to(:temperature_celsius)
+    end
+
+    it "keeps unknown event types as generic SeamEvent instances" do
+      event = described_class.load_from_response(
+        "event_type" => "future.event",
+        "event_id" => "event_1"
+      )
+
+      expect(event).to be_an_instance_of(described_class)
+      expect(event.event_type).to eq("future.event")
+      expect(event.event_id).to eq("event_1")
+    end
+
+    it "renames the event method field without shadowing Object#method" do
+      event = described_class.load_from_response(
+        "event_type" => "lock.locked",
+        "method" => "manual"
+      )
+
+      expect(event.event_method).to eq("manual")
+      expect(event.method(:event_method).call).to eq("manual")
+      expect(described_class::LockLocked.instance_methods(false)).not_to include(:method)
+    end
+  end
+
+  describe Seam::Resources::ActionAttempt do
+    it "loads known action types with action-specific results" do
+      attempt = described_class.load_from_response(
+        action_type: "LOCK_DOOR",
+        status: "success",
+        error: nil,
+        result: {was_confirmed_by_device: true}
+      )
+
+      expect(attempt).to be_a(described_class)
+      expect(attempt).to be_a(described_class::LockDoor)
+      expect(attempt.error).to be_nil
+      expect(attempt.result).to be_a(described_class::LockDoor::Result)
+      expect(attempt.result.was_confirmed_by_device).to be(true)
+    end
+
+    it "allows pending attempts to have nil errors and results" do
+      attempt = described_class.load_from_response(
+        action_type: "UNLOCK_DOOR",
+        status: "pending",
+        error: nil,
+        result: nil
+      )
+
+      expect(attempt.error).to be_nil
+      expect(attempt.result).to be_nil
+    end
+
+    it "keeps unknown action types as generic ActionAttempt instances" do
+      attempt = described_class.load_from_response(
+        action_type: "FUTURE_ACTION",
+        status: "error",
+        error: {message: "Future error"}
+      )
+
+      expect(attempt).to be_an_instance_of(described_class)
+      expect(attempt.action_type).to eq("FUTURE_ACTION")
+      expect(attempt.error).to be_a(described_class::Error)
+      expect(attempt.error.message).to eq("Future error")
+    end
+  end
+end

--- a/spec/resources/resource_errors_spec.rb
+++ b/spec/resources/resource_errors_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "resource errors and warnings" do
   describe "errors" do
-    it "converts error hashes into the resource's own error class" do
+    it "loads a known error code as its variant subclass" do
       device = Seam::Resources::Device.load_from_response(
         "device_id" => "device_id_1234",
         "errors" => [
@@ -15,13 +15,14 @@ RSpec.describe "resource errors and warnings" do
       )
 
       error = device.errors.first
+      expect(error).to be_a(Seam::Resources::Device::Errors::DeviceRemoved)
       expect(error).to be_a(Seam::Resources::Device::Errors)
       expect(error.error_code).to eq("device_removed")
       expect(error.message).to eq("Device was removed")
       expect(error.created_at).to be_a(Time)
     end
 
-    it "exposes the fields only some error variants carry" do
+    it "only exposes fields declared by that error variant" do
       device = Seam::Resources::Device.load_from_response(
         "device_id" => "device_id_1234",
         "errors" => [
@@ -36,15 +37,26 @@ RSpec.describe "resource errors and warnings" do
 
       error = device.errors.first
       expect(error.is_device_error).to be(true)
-      expect(error.is_bridge_error).to be(false)
+      expect(error).not_to respond_to(:is_bridge_error)
+    end
+
+    it "uses the resource's base error class for unknown codes" do
+      device = Seam::Resources::Device.load_from_response(
+        "errors" => [{"error_code" => "future_error", "message" => "Future error"}]
+      )
+
+      error = device.errors.first
+      expect(error).to be_an_instance_of(Seam::Resources::Device::Errors)
+      expect(error.error_code).to eq("future_error")
+      expect(error.message).to eq("Future error")
     end
 
     it "scopes errors to their own resource" do
       expect(Seam::Resources::Device::Errors).not_to be(Seam::Resources::AccessCode::Errors)
-
-      # Only access code errors report which access code the error belongs to.
-      expect(Seam::Resources::AccessCode::Errors.instance_methods).to include(:managed_access_code_id)
-      expect(Seam::Resources::Device::Errors.instance_methods).not_to include(:managed_access_code_id)
+      expect(Seam::Resources::AccessCode::Errors::DuplicateCodeOnDevice.instance_methods)
+        .to include(:managed_access_code_id)
+      expect(Seam::Resources::Device::Errors::DeviceRemoved.instance_methods)
+        .not_to include(:managed_access_code_id)
     end
 
     it "returns an empty array when the resource has no errors" do
@@ -64,7 +76,7 @@ RSpec.describe "resource errors and warnings" do
   end
 
   describe "warnings" do
-    it "converts warning hashes into the resource's own warning class" do
+    it "loads a known warning code as its variant subclass" do
       device = Seam::Resources::Device.load_from_response(
         "device_id" => "device_id_1234",
         "warnings" => [
@@ -77,19 +89,19 @@ RSpec.describe "resource errors and warnings" do
       )
 
       warning = device.warnings.first
+      expect(warning).to be_a(Seam::Resources::Device::Warnings::PrivacyMode)
       expect(warning).to be_a(Seam::Resources::Device::Warnings)
       expect(warning.warning_code).to eq("privacy_mode")
       expect(warning.message).to eq("Device is in privacy mode")
       expect(warning.created_at).to be_a(Time)
     end
 
-    it "exposes the fields only some warning variants carry" do
+    it "exposes fields declared by that warning variant" do
       device = Seam::Resources::Device.load_from_response(
-        "device_id" => "device_id_1234",
         "warnings" => [
           {
-            "warning_code" => "many_active_backup_codes",
-            "message" => "Too many active backup codes",
+            "warning_code" => "max_access_codes_reached",
+            "message" => "Too many active access codes",
             "active_access_code_count" => 12,
             "max_active_access_code_count" => 10
           }
@@ -97,8 +109,20 @@ RSpec.describe "resource errors and warnings" do
       )
 
       warning = device.warnings.first
+      expect(warning).to be_a(Seam::Resources::Device::Warnings::MaxAccessCodesReached)
       expect(warning.active_access_code_count).to eq(12)
       expect(warning.max_active_access_code_count).to eq(10)
+    end
+
+    it "uses the resource's base warning class for unknown codes" do
+      device = Seam::Resources::Device.load_from_response(
+        "warnings" => [{"warning_code" => "future_warning", "message" => "Future warning"}]
+      )
+
+      warning = device.warnings.first
+      expect(warning).to be_an_instance_of(Seam::Resources::Device::Warnings)
+      expect(warning.warning_code).to eq("future_warning")
+      expect(warning.message).to eq("Future warning")
     end
 
     it "returns an empty array when the resource has no warnings" do
@@ -110,7 +134,6 @@ RSpec.describe "resource errors and warnings" do
 
   describe "errors nested inside another shape" do
     it "types errors that are not at the top level of a resource" do
-      # These were skipped at every level before, so they arrived as raw hashes.
       device = Seam::Resources::Device.load_from_response(
         "device_id" => "device_id_1234",
         "properties" => {


### PR DESCRIPTION
## Summary

- generate event subclasses by `event_type` and action-attempt subclasses by `action_type`
- generate per-code error and warning subclasses while retaining generic fallbacks for unknown discriminants
- dispatch variants from `BaseResource.load_from_response` without changing shared `mergeProperties` semantics
- document enum values and correct action-attempt `error`/`result` nullability in YARD
- preserve `is_a?(SeamEvent)` and `is_a?(ActionAttempt)` compatibility through inheritance
- rename event payload `method` access to `event_method` so it no longer shadows `Object#method`
- update webhook documentation and variant behavior specs

## Compatibility

This removes off-variant accessors that previously existed on flattened classes. Although variant instances remain subclasses of the existing base classes, this behavior change should receive a major-version decision before release.

Unknown event types, action types, error codes, and warning codes fall back to their generic base classes for forward compatibility.

## Verification

- `npm run generate`
- `npm run typecheck`
- `npm run lint`
- `rake lint`
- `rake test` — 224 examples, 0 failures

`@seamapi/types` remains pinned at 1.1001.0. RBS signatures are intentionally left out of this change.
