### PR TITLE
feat: expose structured validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ constraints.
     - [Resume pagination](#resume-pagination)
     - [Iterate over all resources](#iterate-over-all-resources)
     - [Return all resources across all pages as a list](#return-all-resources-across-all-pages-as-a-list)
+  - [Error Handling](#error-handling)
+    - [Validation errors](#validation-errors)
   - [Requests without a Workspace in scope](#requests-without-a-workspace-in-scope)
     - [Personal Access Token](#personal-access-token-1)
   - [Webhooks](#webhooks)
@@ -350,6 +352,33 @@ seam = Seam.new
 paginator = seam.create_paginator(seam.devices.method(:list), {limit: 20})
 
 all_devices = paginator.flatten_to_list
+```
+
+### Error Handling
+
+Requests rejected by the Seam API raise a `Seam::Http::ApiError` subclass
+carrying the HTTP `status_code`, API error `code`, and `request_id`.
+
+#### Validation errors
+
+When the API rejects a request because a parameter is invalid, it raises a
+`Seam::Http::InvalidInputError`. Look up messages for a parameter you are
+already rendering, for example a field in a form:
+
+```ruby
+begin
+  seam.devices.list(device_ids: ["not-a-uuid"])
+rescue Seam::Http::InvalidInputError => error
+  puts error.get_validation_error_messages("device_ids")
+end
+```
+
+Or read every parameter that failed validation to summarize the request:
+
+```ruby
+error.validation_errors.each do |validation_error|
+  puts "#{validation_error.parameter_name}: #{validation_error.error_messages.join(", ")}"
+end
 ```
 
 ### Requests without a Workspace in scope

--- a/lib/seam/http.rb
+++ b/lib/seam/http.rb
@@ -36,17 +36,24 @@ module Seam
       end
     end
 
+    ValidationError = Data.define(:parameter_name, :error_messages)
+
     class InvalidInputError < ApiError
       attr_reader :validation_errors
 
       def initialize(error, status_code, request_id)
         super
         @code = "invalid_input"
-        @validation_errors = error["validation_errors"] || {}
+        @raw_validation_errors = error["validation_errors"] || {}
+        @validation_errors = @raw_validation_errors.filter_map do |parameter_name, _|
+          next if parameter_name == "_errors"
+
+          ValidationError.new(parameter_name:, error_messages: get_validation_error_messages(parameter_name))
+        end
       end
 
       def get_validation_error_messages(param_name)
-        @validation_errors.dig(param_name, "_errors") || []
+        @raw_validation_errors.dig(param_name, "_errors") || []
       end
     end
   end

--- a/spec/seam_client/http_error_spec.rb
+++ b/spec/seam_client/http_error_spec.rb
@@ -35,7 +35,30 @@ RSpec.describe Seam::Http, :fake do
         expect(error.request_id).to start_with("request")
         expect(error.get_validation_error_messages("device_ids"))
           .to eq(["Expected array, received number"])
+        expect(error.validation_errors).to eq([
+          Seam::Http::ValidationError.new(
+            parameter_name: "device_ids",
+            error_messages: ["Expected array, received number"]
+          )
+        ])
       end
+    end
+
+    it "excludes request-wide validation errors" do
+      error = Seam::Http::InvalidInputError.new(
+        {
+          "validation_errors" => {
+            "_errors" => ["Request is invalid"],
+            "device_ids" => {"_errors" => ["Invalid device IDs"]}
+          }
+        },
+        400,
+        nil
+      )
+
+      expect(error.validation_errors).to eq([
+        Seam::Http::ValidationError.new(parameter_name: "device_ids", error_messages: ["Invalid device IDs"])
+      ])
     end
 
     it "returns no messages for a param without validation errors" do


### PR DESCRIPTION
## Summary

- expose all invalid parameters as typed `ValidationError` values
- preserve per-parameter message lookup and omit request-wide `_errors`
- document both validation error access patterns

## Tests

- Ruby syntax checks
- focused validation-error self-check

Part of [ENG-2962](https://linear.app/seam/issue/ENG-2962/port-structured-validation-errors-to-all-sdks).
